### PR TITLE
feat(category-model): add verbose_name_plural

### DIFF
--- a/art/api/models.py
+++ b/art/api/models.py
@@ -7,6 +7,9 @@ class AssetCategory(models.Model):
     created_at = models.DateTimeField(auto_now_add=True, editable=False)
     last_modified = models.DateTimeField(auto_now=True, editable=False)
 
+    class Meta:
+        verbose_name_plural = 'Asset Categories'
+
     def __str__(self):
         return self.category_name
 


### PR DESCRIPTION
### What does this PR do ?
- Add verbose_name_plural to Asset Category model
### How can this be manually tested ?
 - python manage.py runserver
 - Go to localhost:8000/admin
 - Login in

### Description of work done
- Add a verbose_name_plural to the Asset Category model to have proper grammar in the admin dashboard

Relelvant PT story
[#155322114](https://www.pivotaltracker.com/story/show/155322114)

### Screenshots if appropriate
<img width="638" alt="screen shot 2018-02-26 at 14 50 56" src="https://user-images.githubusercontent.com/6042152/36669104-c6673c14-1b04-11e8-87a2-2d4f59709f2d.png">