### PR TITLE
[#155512172] Users can be created from an API endpoint

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,0 +1,9 @@
+from rest_framework import serializers
+
+from .models import User
+
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = "__all__"

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -6,4 +6,22 @@ from .models import User
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = "__all__"
+        fields = (
+            'id', 'first_name', 'last_name', 'email', 'cohort',
+            'slack_handle', 'picture', 'phone_number', 'password',
+            'last_modified', 'date_joined', 'last_login'
+        )
+
+        extra_kwargs = {
+            'last_modified': {'read_only': True},
+            'date_joined': {'read_only': True},
+            'last_login': {'read_only': True},
+            'cohort': {'min_value': 0}
+        }
+
+    def create(self, validated_data):
+        password = validated_data.pop('password')
+        user = User(**validated_data)
+        user.set_password(password)
+        user.save()
+        return user

--- a/api/tests/test_user.py
+++ b/api/tests/test_user.py
@@ -178,3 +178,30 @@ class UserTestCase(TestCase):
             'email': ['This field may not be blank.']
         })
         self.assertEqual(response.status_code, 400)
+
+    def test_add_user_api_endpoint_cant_allow_put(self):
+        client.login(username='admin@site.com', password='devpassword')
+        user = User.objects.filter(
+            email='test@site.com').first()
+        response = client.put('/api/v1/user/{}/'.format(user.id))
+        self.assertEqual(response.data, {
+            'detail': 'Method "PUT" not allowed.'
+        })
+
+    def test_add_user_api_endpoint_cant_allow_patch(self):
+        client.login(username='admin@site.com', password='devpassword')
+        user = User.objects.filter(
+            email='test@site.com').first()
+        response = client.patch('/api/v1/user/{}/'.format(user.id))
+        self.assertEqual(response.data, {
+            'detail': 'Method "PATCH" not allowed.'
+        })
+
+    def test_add_user_api_endpoint_cant_allow_delete(self):
+        client.login(username='admin@site.com', password='devpassword')
+        user = User.objects.filter(
+            email='test@site.com').first()
+        response = client.delete('/api/v1/user/{}/'.format(user.id))
+        self.assertEqual(response.data, {
+            'detail': 'Method "DELETE" not allowed.'
+        })

--- a/api/tests/test_user.py
+++ b/api/tests/test_user.py
@@ -16,6 +16,7 @@ class UserTestCase(TestCase):
             email='admin@site.com', cohort=20,
             slack_handle='@admin', password='devpassword'
         )
+        self.users_url = "/api/v1/users/"
 
     def test_can_add_user(self):
         users_count_before = User.objects.count()
@@ -108,14 +109,14 @@ class UserTestCase(TestCase):
             )
 
     def test_non_authenticated_user_add_user_from_api_endpoint(self):
-        response = client.post('/api/v1/user/')
+        response = client.post(self.users_url)
         self.assertEqual(response.data, {
             'detail': 'Authentication credentials were not provided.'
         })
         self.assertEqual(response.status_code, 403)
 
     def test_non_authenticated_user_get_user_from_api_endpoint(self):
-        response = client.get('/api/v1/user/')
+        response = client.get(self.users_url)
         self.assertEqual(response.data, {
             'detail': 'Authentication credentials were not provided.'
         })
@@ -123,7 +124,7 @@ class UserTestCase(TestCase):
 
     def test_non_admin_user_add_user_from_api_endpoint(self):
         client.login(username='test@site.com', password='devpassword')
-        response = client.post('/api/v1/user/')
+        response = client.post(self.users_url)
         self.assertEqual(response.data, {
             'detail': 'Authentication credentials were not provided.'
         })
@@ -131,7 +132,7 @@ class UserTestCase(TestCase):
 
     def test_non_admin_user_et_user_from_api_endpoint(self):
         client.login(username='test@site.com', password='devpassword')
-        response = client.get('/api/v1/user/')
+        response = client.get(self.users_url)
         self.assertEqual(response.data, {
             'detail': 'Authentication credentials were not provided.'
         })
@@ -144,14 +145,14 @@ class UserTestCase(TestCase):
             "password": "devpassword",
             "email": "test_user@mail.com",
         }
-        response = client.post('/api/v1/user/', data=data, format='json')
+        response = client.post(self.users_url, data=data, format='json')
         users_count_after = User.objects.count()
         self.assertEqual(response.status_code, 201)
         self.assertEqual(users_count_after, users_count_before + 1)
 
     def test_admin_user_get_users_from_api_endpoint(self):
         client.login(username='admin@site.com', password='devpassword')
-        response = client.get('/api/v1/user/')
+        response = client.get(self.users_url)
         self.assertEqual(len(response.data), User.objects.count())
         self.assertEqual(response.status_code, 200)
 
@@ -161,7 +162,7 @@ class UserTestCase(TestCase):
             "password": "",
             "email": "test_user@mail.com",
         }
-        response = client.post('/api/v1/user/', data=data, format='json')
+        response = client.post(self.users_url, data=data, format='json')
         self.assertEqual(response.data, {
             'password': ['This field may not be blank.']
         })
@@ -173,7 +174,7 @@ class UserTestCase(TestCase):
             "password": "devpassword",
             "email": "",
         }
-        response = client.post('/api/v1/user/', data=data, format='json')
+        response = client.post(self.users_url, data=data, format='json')
         self.assertEqual(response.data, {
             'email': ['This field may not be blank.']
         })
@@ -183,7 +184,7 @@ class UserTestCase(TestCase):
         client.login(username='admin@site.com', password='devpassword')
         user = User.objects.filter(
             email='test@site.com').first()
-        response = client.put('/api/v1/user/{}/'.format(user.id))
+        response = client.put('{}{}/'.format(self.users_url, user.id))
         self.assertEqual(response.data, {
             'detail': 'Method "PUT" not allowed.'
         })
@@ -192,7 +193,7 @@ class UserTestCase(TestCase):
         client.login(username='admin@site.com', password='devpassword')
         user = User.objects.filter(
             email='test@site.com').first()
-        response = client.patch('/api/v1/user/{}/'.format(user.id))
+        response = client.patch('{}{}/'.format(self.users_url, user.id))
         self.assertEqual(response.data, {
             'detail': 'Method "PATCH" not allowed.'
         })
@@ -201,7 +202,7 @@ class UserTestCase(TestCase):
         client.login(username='admin@site.com', password='devpassword')
         user = User.objects.filter(
             email='test@site.com').first()
-        response = client.delete('/api/v1/user/{}/'.format(user.id))
+        response = client.delete('{}{}/'.format(self.users_url, user.id))
         self.assertEqual(response.data, {
             'detail': 'Method "DELETE" not allowed.'
         })

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,0 +1,7 @@
+from rest_framework.routers import SimpleRouter
+
+from .views import UserViewSet
+
+router = SimpleRouter()
+router.register('api/v1/user', UserViewSet)
+urlpatterns = router.urls

--- a/api/urls.py
+++ b/api/urls.py
@@ -3,5 +3,5 @@ from rest_framework.routers import SimpleRouter
 from .views import UserViewSet
 
 router = SimpleRouter()
-router.register('api/v1/user', UserViewSet)
+router.register('user', UserViewSet)
 urlpatterns = router.urls

--- a/api/urls.py
+++ b/api/urls.py
@@ -3,5 +3,5 @@ from rest_framework.routers import SimpleRouter
 from .views import UserViewSet
 
 router = SimpleRouter()
-router.register('user', UserViewSet)
+router.register('users', UserViewSet)
 urlpatterns = router.urls

--- a/api/views.py
+++ b/api/views.py
@@ -1,3 +1,13 @@
-# from django.shortcuts import render
+from django.contrib.auth import get_user_model
+from rest_framework.permissions import IsAuthenticated, IsAdminUser
+from rest_framework.viewsets import ModelViewSet
 
-# Create your views here.
+from .serializers import UserSerializer
+
+User = get_user_model()
+
+
+class UserViewSet(ModelViewSet):
+    serializer_class = UserSerializer
+    queryset = User.objects.all()
+    permission_classes = (IsAuthenticated, IsAdminUser)

--- a/api/views.py
+++ b/api/views.py
@@ -11,3 +11,4 @@ class UserViewSet(ModelViewSet):
     serializer_class = UserSerializer
     queryset = User.objects.all()
     permission_classes = (IsAuthenticated, IsAdminUser)
+    http_method_names = ['get', 'post']

--- a/art/urls.py
+++ b/art/urls.py
@@ -18,9 +18,12 @@ from django.conf import settings
 from django.conf.urls import include
 from django.urls import path
 
+from api import urls
+
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('', include(urls)),
 ]
 if settings.DEBUG:
     import debug_toolbar

--- a/art/urls.py
+++ b/art/urls.py
@@ -23,7 +23,7 @@ from api import urls
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('', include(urls)),
+    path('api/v1/', include(urls)),
 ]
 if settings.DEBUG:
     import debug_toolbar


### PR DESCRIPTION
#### What does this PR do?

Allow users to be created from an API endpoint

#### Description of Task to be completed?

- add test for functionality
- add user serializer
- add user viewset
- add user url patterns

#### How should this be manually tested?

`python manage.py test`
or 
endpoint `/api/v1/user` in your browser

#### Any background context you want to provide?

only admin user can add users
#### What are the relevant pivotal tracker stories?

[#155512172](https://www.pivotaltracker.com/n/projects/2146417/stories/155512172)

#### Screenshots 
![user-home](https://user-images.githubusercontent.com/24381733/37395486-5f9ad0f6-2787-11e8-8da6-35074e1a4e3c.jpg)

![single-user](https://user-images.githubusercontent.com/24381733/37395400-2f54f336-2787-11e8-9341-90b14d1f00bb.jpg)


