### PR TITLE
[#155322124] Fix: Add whitenoise for Heroku

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ python-decouple==3.1
 pytz==2017.3
 urllib3==1.22
 virtualenv==15.1.0
+whitenoise==3.3.1


### PR DESCRIPTION
### What does this PR do ?
- Add missing whitenoise module

