### PR TITLE
[#155922718] user can see assets allocated to them via API

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from .models import User
+from .models import User, Item
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -25,3 +25,11 @@ class UserSerializer(serializers.ModelSerializer):
         user.set_password(password)
         user.save()
         return user
+
+
+class ItemSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Item
+        fields = ("id", "item_code", "serial_number", "model_number",
+                  "assigned_to", "created_at", "last_modified",
+                  )

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -31,5 +31,5 @@ class ItemSerializer(serializers.ModelSerializer):
     class Meta:
         model = Item
         fields = ("id", "item_code", "serial_number", "model_number",
-                  "assigned_to", "created_at", "last_modified",
+                  "status", "assigned_to", "created_at", "last_modified",
                   )

--- a/api/tests/test_item_api.py
+++ b/api/tests/test_item_api.py
@@ -25,7 +25,8 @@ class ItemTestCase(TestCase):
             item_code="IC001",
             serial_number="SN001",
             assigned_to=self.user,
-            model_number=itemmodel
+            model_number=itemmodel,
+            status="Allocated"
         )
         item.save()
         self.item = item

--- a/api/tests/test_item_api.py
+++ b/api/tests/test_item_api.py
@@ -1,0 +1,85 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+
+from ..models import Item, ItemModelNumber
+
+User = get_user_model()
+client = APIClient()
+
+
+class ItemTestCase(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email='user@site.com', cohort=20,
+            slack_handle='@admin', password='devpassword'
+        )
+        self.other_user = User.objects.create_user(
+            email='user1@site.com', cohort=20,
+            slack_handle='@admin', password='devpassword'
+        )
+        itemmodel = ItemModelNumber(model_number="IMN50987")
+        itemmodel.save()
+        item = Item(
+            item_code="IC001",
+            serial_number="SN001",
+            assigned_to=self.user,
+            model_number=itemmodel
+        )
+        item.save()
+        self.item = item
+        self.items_url = "/api/v1/items/"
+
+    def test_non_authenticated_user_view_items(self):
+        response = client.get(self.items_url)
+        self.assertEqual(response.data, {
+            'detail': 'Authentication credentials were not provided.'
+        })
+
+    def test_authenticated_non_owner_view_items(self):
+        client.login(username='user1@site.com', password='devpassword')
+        response = client.get(self.items_url)
+        self.assertEqual(response.data, [])
+        self.assertEqual(len(response.data), Item.objects.count() - 1)
+        self.assertEqual(response.status_code, 200)
+
+    def test_authenticated_owner_view_items(self):
+        client.login(username='user@site.com', password='devpassword')
+        response = client.get(self.items_url)
+        self.assertIn(self.item.item_code, response.data[0].values())
+        self.assertEqual(len(response.data), Item.objects.count())
+        self.assertEqual(response.status_code, 200)
+
+    def test_authenticated_owner_view_single_item(self):
+        client.login(username='user@site.com', password='devpassword')
+        response = client.get("{}{}/".format(self.items_url, self.item.id))
+        self.assertIn(self.item.item_code, response.data.values())
+        self.assertEqual(response.status_code, 200)
+
+    def test_items_api_endpoint_cant_allow_post(self):
+        client.login(username='user1@site.com', password='devpassword')
+        response = client.post(self.items_url)
+        self.assertEqual(response.data, {
+            'detail': 'Method "POST" not allowed.'
+        })
+
+    def test_items_api_endpoint_cant_allow_put(self):
+        client.login(username='user1@site.com', password='devpassword')
+        response = client.put('{}{}/'.format(self.items_url, self.item.id))
+        self.assertEqual(response.data, {
+            'detail': 'Method "PUT" not allowed.'
+        })
+
+    def test_items_api_endpoint_cant_allow_patch(self):
+        client.login(username='user1@site.com', password='devpassword')
+        response = client.patch('{}{}/'.format(self.items_url, self.item.id))
+        self.assertEqual(response.data, {
+            'detail': 'Method "PATCH" not allowed.'
+        })
+
+    def test_items_api_endpoint_cant_allow_delete(self):
+        client.login(username='user1@site.com', password='devpassword')
+        response = client.delete('{}{}/'.format(self.items_url, self.item.id))
+        self.assertEqual(response.data, {
+            'detail': 'Method "DELETE" not allowed.'
+        })

--- a/api/tests/test_item_api.py
+++ b/api/tests/test_item_api.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 from django.contrib.auth import get_user_model
+from rest_framework.reverse import reverse
 from rest_framework.test import APIClient
 
 from ..models import Item, ItemModelNumber
@@ -28,7 +29,7 @@ class ItemTestCase(TestCase):
         )
         item.save()
         self.item = item
-        self.items_url = "/api/v1/items/"
+        self.items_url = reverse('items-list')
 
     def test_non_authenticated_user_view_items(self):
         response = client.get(self.items_url)

--- a/api/tests/test_item_model.py
+++ b/api/tests/test_item_model.py
@@ -35,7 +35,8 @@ class ItemTypeModelTest(TestCase):
         self.assertEqual(self.all_items.count(), 1)
         new_item = Item(item_code="IC002",
                         serial_number="SN001",
-                        model_number=self.test_itemmodel)
+                        model_number=self.test_itemmodel,
+                        assigned_to=self.user)
         new_item.save()
         self.assertEqual(self.all_items.count(), 2)
 

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,7 +1,8 @@
 from rest_framework.routers import SimpleRouter
 
-from .views import UserViewSet
+from .views import UserViewSet, ItemViewSet
 
 router = SimpleRouter()
 router.register('users', UserViewSet)
+router.register('items', ItemViewSet, 'items')
 urlpatterns = router.urls

--- a/api/views.py
+++ b/api/views.py
@@ -2,7 +2,8 @@ from django.contrib.auth import get_user_model
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
 from rest_framework.viewsets import ModelViewSet
 
-from .serializers import UserSerializer
+from .models import Item
+from .serializers import UserSerializer, ItemSerializer
 
 User = get_user_model()
 
@@ -12,3 +13,14 @@ class UserViewSet(ModelViewSet):
     queryset = User.objects.all()
     permission_classes = (IsAuthenticated, IsAdminUser)
     http_method_names = ['get', 'post']
+
+
+class ItemViewSet(ModelViewSet):
+    serializer_class = ItemSerializer
+    permission_classes = [IsAuthenticated, ]
+    http_method_names = ['get']
+
+    def get_queryset(self):
+
+        user = self.request.user
+        return Item.objects.filter(assigned_to=user)

--- a/art/urls.py
+++ b/art/urls.py
@@ -21,12 +21,12 @@ from django.urls import path
 
 from api import urls
 
-
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/v1/', include(urls)),
     path('jet/', include('jet.urls', 'jet')),
     path('jet/dashboard/', include('jet.dashboard.urls', 'jet-dashboard')),
+    path('api-auth/', include('rest_framework.urls')),
 ]
 if settings.DEBUG:
     import debug_toolbar


### PR DESCRIPTION
#### What does this PR do?

Allow users to view assets allocated to them via API

#### Description of Task to be completed?

- add test for functionality
- add item serializer
- add item viewset
- register item url

#### How should this be manually tested?

`python manage.py test`
or 
endpoint `/api-auth/login` to login user
endpoint `/api/v1/items` to view assets

#### Any background context you want to provide?

Included `api-auth` route to allow user login
#### What are the relevant pivotal tracker stories?

[#155922718](https://www.pivotaltracker.com/n/projects/2146417/stories/155922718)

#### Screenshots 
![non_auth](https://user-images.githubusercontent.com/24381733/37752653-2960ec5e-2daa-11e8-8975-5e06f198d406.jpg)
![test_user](https://user-images.githubusercontent.com/24381733/37752665-37327f50-2daa-11e8-9d16-3798b492632c.jpg)
![test_user_1](https://user-images.githubusercontent.com/24381733/37752675-41bbdc64-2daa-11e8-8acf-9e9dd856f41f.jpg)


[delivers #155922718