### PR TITLE
[#155922719] user can see details for a specific asset via API 

### DIFF
--- a/api/tests/test_item_api.py
+++ b/api/tests/test_item_api.py
@@ -54,7 +54,8 @@ class ItemTestCase(TestCase):
 
     def test_authenticated_owner_view_single_item(self):
         client.login(username='user@site.com', password='devpassword')
-        response = client.get("{}{}/".format(self.items_url, self.item.id))
+        response = client.get("{}{}/".format(self.items_url,
+                                             self.item.serial_number))
         self.assertIn(self.item.item_code, response.data.values())
         self.assertEqual(response.status_code, 200)
 

--- a/api/views.py
+++ b/api/views.py
@@ -26,6 +26,6 @@ class ItemViewSet(ModelViewSet):
         return Item.objects.filter(assigned_to=user)
 
     def get_object(self):
-        queryset = self.get_queryset()
+        queryset = Item.objects.filter(assigned_to=self.request.user)
         obj = get_object_or_404(queryset, serial_number=self.kwargs['pk'])
         return obj

--- a/api/views.py
+++ b/api/views.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import get_user_model
+from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
 from rest_framework.viewsets import ModelViewSet
 
@@ -20,8 +21,11 @@ class ItemViewSet(ModelViewSet):
     permission_classes = [IsAuthenticated, ]
     http_method_names = ['get']
 
-    def get_queryset(self, pk=1):
-        if pk:
-            return Item.objects.filter(serial_number=pk)          
+    def get_queryset(self):
         user = self.request.user
         return Item.objects.filter(assigned_to=user)
+
+    def get_object(self):
+        queryset = self.get_queryset()
+        obj = get_object_or_404(queryset, serial_number=self.kwargs['pk'])
+        return obj

--- a/api/views.py
+++ b/api/views.py
@@ -20,7 +20,8 @@ class ItemViewSet(ModelViewSet):
     permission_classes = [IsAuthenticated, ]
     http_method_names = ['get']
 
-    def get_queryset(self):
-
+    def get_queryset(self, pk=1):
+        if pk:
+            return Item.objects.filter(serial_number=pk)          
         user = self.request.user
         return Item.objects.filter(assigned_to=user)


### PR DESCRIPTION
#### What does this PR do?

Allow users to view a specific asset details by serial number via API 

#### Description of Task to be completed?

- add test for functionality
- add item viewset get object by serial number

#### How should this be manually tested?

`python manage.py test`
or 
endpoint `/api-auth/login` to login user
endpoint `/api/v1/items/{serial_number}` to view asset details

#### What are the relevant pivotal tracker stories?

[#155922719](https://www.pivotaltracker.com/n/projects/2146417/stories/155922719)

#### Screenshots 
![view-by-serial](https://user-images.githubusercontent.com/24381733/37907428-c42c4d80-310d-11e8-90a0-a7ad4f323320.jpg)



[delivers #155922719]