### PR TITLE
[#156224442] Add email address for security users

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,4 +6,5 @@ omit =
     */manage.py
     */tests/*
     */static/*
+    */api/apps.py
 show_missing = True

--- a/api/admin.py
+++ b/api/admin.py
@@ -24,8 +24,11 @@ admin.site.register(
 
 class SecurityUserAdmin(BaseUserAdmin):
     list_display = (
-        'first_name', 'last_name',
-        'badge_number', 'phone_number',
+        'first_name',
+        'last_name',
+        'email',
+        'badge_number',
+        'phone_number',
     )
 
     list_filter = (
@@ -33,7 +36,9 @@ class SecurityUserAdmin(BaseUserAdmin):
     )
 
     fieldsets = (
-        ('Account', {'fields': ('first_name', 'last_name',
+        ('Account', {'fields': ('first_name',
+                                'last_name',
+                                'email',
                                 'badge_number',
                                 'phone_number',
                                 'password')}),
@@ -43,7 +48,9 @@ class SecurityUserAdmin(BaseUserAdmin):
         (None, {
             'classes': ('wide',),
             'fields': ('first_name',
-                       'last_name', 'badge_number',
+                       'last_name',
+                       'email',
+                       'badge_number',
                        'phone_number',
                        'password1',
                        'password2')

--- a/api/models.py
+++ b/api/models.py
@@ -187,5 +187,4 @@ class SecurityUser(User):
         verbose_name = "Security User"
 
     def save(self, *args, **kwargs):
-
         super().save(*args, **kwargs)

--- a/api/models.py
+++ b/api/models.py
@@ -187,8 +187,5 @@ class SecurityUser(User):
         verbose_name = "Security User"
 
     def save(self, *args, **kwargs):
-        if not self.email:
-            user_email = "{}@example.com".format(self.badge_number)
-            self.email = user_email
 
         super().save(*args, **kwargs)

--- a/api/models.py
+++ b/api/models.py
@@ -185,6 +185,3 @@ class SecurityUser(User):
 
     class Meta:
         verbose_name = "Security User"
-
-    def save(self, *args, **kwargs):
-        super().save(*args, **kwargs)

--- a/api/tests/test_security_user_model.py
+++ b/api/tests/test_security_user_model.py
@@ -6,6 +6,7 @@ class SecurityUserModelTest(TestCase):
     """ Tests for the Security User Model """
     def setUp(self):
         SecurityUser.objects.create(
+            email="sectest1@andela.com",
             password="devpassword",
             first_name="TestFirst",
             last_name="TestLast",
@@ -19,6 +20,7 @@ class SecurityUserModelTest(TestCase):
 
     def test_can_save_a_security_user(self):
         SecurityUser.objects.create(
+            email="sectest2@andela.com",
             password="devpassword2",
             first_name="NewPerson",
             last_name="LastName",


### PR DESCRIPTION
### What does this PR do ?
- Allow the admin to add an email address for security users

### Description of work done
- change admin dashboard view to include email address
- remove code in `def save()`  that adds custom email address in security model
- refactor tests to include email address

### Screenshots if appropriate
![screen shot 2018-03-28 at 11 54 11](https://user-images.githubusercontent.com/6042152/38018855-c5a293be-327e-11e8-9033-db95f3c98d07.png)

### Relevant PT Story
[#156224442](https://www.pivotaltracker.com/story/show/156224442)