### PR TITLE
[#156267228] User can see security users email addresses

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -38,4 +38,4 @@ class ItemSerializer(serializers.ModelSerializer):
 class SecuritySerializer(serializers.ModelSerializer):
     class Meta:
         model = SecurityUser
-        fields = ("id", "email", "badge_number")
+        fields = ("email", )

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from .models import User, Item
+from .models import User, Item, SecurityUser
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -33,3 +33,9 @@ class ItemSerializer(serializers.ModelSerializer):
         fields = ("id", "item_code", "serial_number", "model_number",
                   "status", "assigned_to", "created_at", "last_modified",
                   )
+
+
+class SecuritySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SecurityUser
+        fields = ("id", "email", "badge_number")

--- a/api/tests/test_security_user.py
+++ b/api/tests/test_security_user.py
@@ -1,12 +1,14 @@
-from .test_user import UserTestCase, client, patch
+from django.test import TestCase
+from rest_framework.reverse import reverse
+from rest_framework.test import APIClient
+
 from ..models import SecurityUser
+client = APIClient()
 
 
-class SecurityUserTestCase(UserTestCase):
+class SecurityUserTestCase(TestCase):
     def setUp(self):
-        UserTestCase.setUp(self)
-
-        self.security_users = "/api/v1/security_users/"
+        self.security_users_url = reverse('security_users-list')
 
         SecurityUser.objects.create(
             email="sectest1@andela.com",
@@ -25,33 +27,8 @@ class SecurityUserTestCase(UserTestCase):
             badge_number="AE24"
         )
 
-    @patch('api.authentication.auth.verify_id_token')
-    def test_admin_can_get_security_users_emails(self, mock_verify_token):
-        mock_verify_token.return_value = {'email': self.admin_user.email}
-        response = client.get(
-            self.security_users,
-            HTTP_AUTHORIZATION="Token {}".format(self.token_admin)
-        )
+    def test_admin_can_get_security_users_emails(self):
+        response = client.get(self.security_users_url)
         self.assertEqual(len(response.data["emails"]),
                          SecurityUser.objects.count())
         self.assertEqual(response.status_code, 200)
-
-    @patch('api.authentication.auth.verify_id_token')
-    def test_user_can_get_security_users_emails(self, mock_verify_token):
-        mock_verify_token.return_value = {'email': self.user.email}
-        response = client.get(
-            self.security_users,
-            HTTP_AUTHORIZATION="Token {}".format(self.token_admin)
-        )
-
-        self.assertIn(response.data["emails"][0], "sectest1@andela.com")
-        self.assertIn(response.data["emails"][1], "sectest2@andela.com")
-
-    @patch('api.authentication.auth.verify_id_token')
-    def test_non_user_cannot_get_security_emails(self, mock_verify_token):
-        mock_verify_token.return_value = {"email": "nonuser@example.com"}
-        response = client.get(
-            self.security_users,
-            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
-        self.assertEqual(response.data, {"detail": "Unable to authenticate."})
-        self.assertEqual(response.status_code, 401)

--- a/api/tests/test_security_user.py
+++ b/api/tests/test_security_user.py
@@ -1,5 +1,4 @@
-
-from .test_user import UserTestCase, client
+from .test_user import UserTestCase, client, patch
 from ..models import SecurityUser
 
 
@@ -26,15 +25,33 @@ class SecurityUserTestCase(UserTestCase):
             badge_number="AE24"
         )
 
-    def test_admin_can_get_security_users_emails(self):
-        client.login(username='admin@site.com', password='devpassword')
-        response = client.get(self.security_users)
-        self.assertEqual(len(response.data), SecurityUser.objects.count())
+    @patch('api.authentication.auth.verify_id_token')
+    def test_admin_can_get_security_users_emails(self, mock_verify_token):
+        mock_verify_token.return_value = {'email': self.admin_user.email}
+        response = client.get(
+            self.security_users,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_admin)
+        )
+        self.assertEqual(len(response.data["emails"]),
+                         SecurityUser.objects.count())
         self.assertEqual(response.status_code, 200)
 
-    def test_unauthenticated_user_cannot_get_security_users_emails(self):
-        response = client.get(self.security_users)
-        self.assertEqual(response.data, {
-            "detail": "Authentication credentials were not provided."
-        })
-        self.assertEqual(response.status_code, 403)
+    @patch('api.authentication.auth.verify_id_token')
+    def test_user_can_get_security_users_emails(self, mock_verify_token):
+        mock_verify_token.return_value = {'email': self.user.email}
+        response = client.get(
+            self.security_users,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_admin)
+        )
+
+        self.assertIn(response.data["emails"][0], "sectest1@andela.com")
+        self.assertIn(response.data["emails"][1], "sectest2@andela.com")
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_non_user_cannot_get_security_emails(self, mock_verify_token):
+        mock_verify_token.return_value = {"email": "nonuser@example.com"}
+        response = client.get(
+            self.security_users,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(response.data, {"detail": "Unable to authenticate."})
+        self.assertEqual(response.status_code, 401)

--- a/api/tests/test_security_user.py
+++ b/api/tests/test_security_user.py
@@ -1,0 +1,40 @@
+
+from .test_user import UserTestCase, client
+from ..models import SecurityUser
+
+
+class SecurityUserTestCase(UserTestCase):
+    def setUp(self):
+        UserTestCase.setUp(self)
+
+        self.security_users = "/api/v1/security_users/"
+
+        SecurityUser.objects.create(
+            email="sectest1@andela.com",
+            password="devpassword",
+            first_name="TestFirst",
+            last_name="TestLast",
+            phone_number="254720900900",
+            badge_number="AE23"
+        )
+        SecurityUser.objects.create(
+            email="sectest2@andela.com",
+            password="devpassword",
+            first_name="TestFirst2",
+            last_name="TestLast2",
+            phone_number="254720900900",
+            badge_number="AE24"
+        )
+
+    def test_admin_can_get_security_users_emails(self):
+        client.login(username='admin@site.com', password='devpassword')
+        response = client.get(self.security_users)
+        self.assertEqual(len(response.data), SecurityUser.objects.count())
+        self.assertEqual(response.status_code, 200)
+
+    def test_unauthenticated_user_cannot_get_security_users_emails(self):
+        response = client.get(self.security_users)
+        self.assertEqual(response.data, {
+            "detail": "Authentication credentials were not provided."
+        })
+        self.assertEqual(response.status_code, 403)

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,9 +1,9 @@
 from rest_framework.routers import SimpleRouter
 
-from .views import UserViewSet, ItemViewSet
+from .views import UserViewSet, ItemViewSet, SecurityUserViewSet
 
 router = SimpleRouter()
 router.register('users', UserViewSet)
 router.register('items', ItemViewSet, 'items')
-
+router.register('security_users', SecurityUserViewSet, 'security_users')
 urlpatterns = router.urls

--- a/api/views.py
+++ b/api/views.py
@@ -40,11 +40,8 @@ class SecurityUserViewSet(ModelViewSet):
     http_method_names = ['get']
 
     def list(self, request, *args, **kwargs):
-        security_emails = SecurityUser.objects.all()
 
-        list_of_emails = []
-
-        for security_email in security_emails:
-            list_of_emails.append(security_email.email)
+        list_of_emails = [security_user.email
+                          for security_user in SecurityUser.objects.all()]
 
         return Response({'emails': list_of_emails}, status=status.HTTP_200_OK)

--- a/api/views.py
+++ b/api/views.py
@@ -1,5 +1,7 @@
 from django.contrib.auth import get_user_model
 from rest_framework.generics import get_object_or_404
+from rest_framework.response import Response
+from rest_framework import status
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
 from rest_framework.viewsets import ModelViewSet
 from api.authentication import FirebaseTokenAuthentication
@@ -36,7 +38,15 @@ class ItemViewSet(ModelViewSet):
 class SecurityUserViewSet(ModelViewSet):
     serializer_class = SecuritySerializer
     permission_classes = [IsAuthenticated, ]
+    authentication_classes = (FirebaseTokenAuthentication,)
     http_method_names = ['get']
 
-    def get_queryset(self):
-        return SecurityUser.objects.all()
+    def list(self, request, *args, **kwargs):
+        security_emails = SecurityUser.objects.all()
+
+        list_of_emails = []
+
+        for security_email in security_emails:
+            list_of_emails.append(security_email.email)
+
+        return Response({'emails': list_of_emails}, status=status.HTTP_200_OK)

--- a/api/views.py
+++ b/api/views.py
@@ -3,8 +3,8 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
 from rest_framework.viewsets import ModelViewSet
 from api.authentication import FirebaseTokenAuthentication
-from .models import Item
-from .serializers import UserSerializer, ItemSerializer
+from .models import Item, SecurityUser
+from .serializers import UserSerializer, ItemSerializer, SecuritySerializer
 
 User = get_user_model()
 
@@ -31,3 +31,12 @@ class ItemViewSet(ModelViewSet):
         queryset = Item.objects.filter(assigned_to=self.request.user)
         obj = get_object_or_404(queryset, serial_number=self.kwargs['pk'])
         return obj
+
+
+class SecurityUserViewSet(ModelViewSet):
+    serializer_class = SecuritySerializer
+    permission_classes = [IsAuthenticated, ]
+    http_method_names = ['get']
+
+    def get_queryset(self):
+        return SecurityUser.objects.all()

--- a/api/views.py
+++ b/api/views.py
@@ -37,8 +37,6 @@ class ItemViewSet(ModelViewSet):
 
 class SecurityUserViewSet(ModelViewSet):
     serializer_class = SecuritySerializer
-    permission_classes = [IsAuthenticated, ]
-    authentication_classes = (FirebaseTokenAuthentication,)
     http_method_names = ['get']
 
     def list(self, request, *args, **kwargs):


### PR DESCRIPTION
### What does this PR do ?
A user can see all security users (email addresses) via the API
### Description of work done
- add security serializer
- add security viewset
- add security url
- add test to list security users

### How can this be manually tested ?
- `python manage.py test`
- Via Postman: 
     - Login to the API using your credentials
     - go to the route `http://localhost:8000/api/v1/security_users/`
     -  You will see a list of security users depending on whether you have added a security user in your admin dashboard

### Screenshots 
<img width="689" alt="screen shot 2018-04-05 at 17 40 02" src="https://user-images.githubusercontent.com/6042152/38372885-8e3b85f4-38f8-11e8-901f-93dc3ca096b2.png">

<img width="1120" alt="screen shot 2018-04-03 at 15 39 46" src="https://user-images.githubusercontent.com/6042152/38249968-1f790824-3756-11e8-9836-821346000401.png">

### Relevant PT story
[#156267228](https://www.pivotaltracker.com/story/show/156267228)
