### PR TITLE
[#156990530] Make password field optional for security user

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
-from .forms import UserRegistrationForm, SecurityUserRegistrationForm
+from .forms import UserRegistrationForm
 from .models import (AssetCategory, AssetType,
                      AssetSubCategory,
                      Asset,
@@ -26,7 +26,7 @@ admin.site.register(
 
 
 class SecurityUserAdmin(BaseUserAdmin):
-    add_form = SecurityUserRegistrationForm
+    add_form = UserRegistrationForm
     list_display = (
         'first_name',
         'last_name',

--- a/api/admin.py
+++ b/api/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
-from .forms import UserRegistrationForm
+from .forms import UserRegistrationForm, SecurityUserRegistrationForm
 from .models import (AssetCategory, AssetType,
                      AssetSubCategory,
                      Asset,
@@ -26,6 +26,7 @@ admin.site.register(
 
 
 class SecurityUserAdmin(BaseUserAdmin):
+    add_form = SecurityUserRegistrationForm
     list_display = (
         'first_name',
         'last_name',

--- a/api/forms.py
+++ b/api/forms.py
@@ -19,3 +19,7 @@ class UserRegistrationForm(UserCreationForm):
         help_text=_("Enter the same password as before, for verification."),
         required=False
     )
+
+
+class SecurityUserRegistrationForm(UserRegistrationForm):
+    pass

--- a/api/forms.py
+++ b/api/forms.py
@@ -19,7 +19,3 @@ class UserRegistrationForm(UserCreationForm):
         help_text=_("Enter the same password as before, for verification."),
         required=False
     )
-
-
-class SecurityUserRegistrationForm(UserRegistrationForm):
-    pass

--- a/api/tests/test_security_user_model.py
+++ b/api/tests/test_security_user_model.py
@@ -57,6 +57,7 @@ class SecurityUserModelTest(TestCase):
         self.assertEqual(SecurityUser.objects.count(), 1)
 
     def test_can_add_security_user_without_password(self):
+        initial_count = SecurityUser.objects.count()
         SecurityUser.objects.create(
             email="sectest98@andela.com",
             first_name="TestNew",
@@ -69,5 +70,6 @@ class SecurityUserModelTest(TestCase):
             badge_number="AXW23"
         )
 
+        self.assertEqual(initial_count, 1)
         self.assertEqual(SecurityUser.objects.count(), 2)
         self.assertIn("TestNew", new_security_user.first_name)

--- a/api/tests/test_security_user_model.py
+++ b/api/tests/test_security_user_model.py
@@ -55,3 +55,19 @@ class SecurityUserModelTest(TestCase):
         new_security_member.delete()
         self.assertEqual(new_security_team, 2)
         self.assertEqual(SecurityUser.objects.count(), 1)
+
+    def test_can_add_security_user_without_password(self):
+        SecurityUser.objects.create(
+            email="sectest98@andela.com",
+            first_name="TestNew",
+            last_name="TestLastNew",
+            phone_number="254720900901",
+            badge_number="AXW23"
+        )
+
+        new_security_user = SecurityUser.objects.get(
+            badge_number="AXW23"
+        )
+
+        self.assertEqual(SecurityUser.objects.count(), 2)
+        self.assertIn("TestNew", new_security_user.first_name)


### PR DESCRIPTION
### What does this PR do ?
Makes the password field optional for security users
### Description of work done
- write test for optional password
- add `SecurityUserRegistrationForm` class
- import `SecurityUserRegistrationForm`  and use it  in `SecurityUserAdmin` class
### How can I manually test this ?
- `python manage.py runserver` AND , OR
- Login into the admin dashboard
- Add a security user and leave out the `password` and `password confirmation` fields.
- Click `Save`. You should see a `success` message indicating the user has been added.