### PR TITLE
[#157103974] User can track item status via API

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 
 from core.models import (
     User, Asset, SecurityUser, AssetLog,
-    UserFeedback, CHECKIN, CHECKOUT
+    UserFeedback, CHECKIN, CHECKOUT, AssetStatus
 )
 
 
@@ -83,3 +83,25 @@ class UserFeedbackSerializer(serializers.ModelSerializer):
         model = UserFeedback
         fields = ("reported_by", "message", "report_type", "created_at")
         read_only_fields = ("reported_by", )
+
+
+class AssetStatusSerializer(AssetSerializer):
+    status_history = serializers.SerializerMethodField()
+
+    class Meta:
+        model = AssetStatus
+        fields = ("id", "asset", "current_status", "status_history",
+                  "previous_status", "created_at")
+
+    def get_status_history(self, obj):
+        asset_status = AssetStatus.objects.filter(asset=obj.asset)
+        return [
+            {
+                "id": asset.id,
+                "asset": asset.asset_id,
+                "current_status": asset.current_status,
+                "previous_status": asset.previous_status,
+                "created_at": asset.created_at
+            }
+            for asset in asset_status if obj.created_at > asset.created_at
+        ]

--- a/api/tests/test_asset_api.py
+++ b/api/tests/test_asset_api.py
@@ -49,7 +49,7 @@ class AssetTestCase(TestCase):
         })
 
     @patch('api.authentication.auth.verify_id_token')
-    def test_authenticated_non_owner_view_assets(self, mock_verify_id_token):
+    def test_authenticated_user_view_assets(self, mock_verify_id_token):
         mock_verify_id_token.return_value = {'email': self.other_user.email}
         response = client.get(
             self.asset_urls,

--- a/api/tests/test_asset_status_api.py
+++ b/api/tests/test_asset_status_api.py
@@ -1,0 +1,166 @@
+from unittest.mock import patch
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from rest_framework.reverse import reverse
+from rest_framework.test import APIClient
+
+from core.models import Asset, AssetModelNumber, AssetStatus
+
+User = get_user_model()
+client = APIClient()
+
+
+class AssetStatusAPITest(TestCase):
+    """Tests for the Asset Status API"""
+
+    def setUp(self):
+        self.test_assetmodel1 = AssetModelNumber(model_number="IMN50987")
+        self.test_assetmodel1.save()
+        self.token_user = 'testtoken'
+
+        self.normal_user = User.objects.create(
+            email='test@site.com', cohort=10,
+            slack_handle='@test_user', password='devpassword'
+        )
+
+        self.test_asset = Asset(
+            asset_code="IC001",
+            serial_number="SN001",
+            model_number=self.test_assetmodel1,
+            assigned_to=self.normal_user
+        )
+        self.test_asset.save()
+        self.asset = Asset.objects.get(asset_code="IC001")
+        self.asset_status = AssetStatus.objects.get(asset=self.asset)
+
+        self.asset_status_urls = reverse('asset-status-list')
+
+    def test_non_authenticated_user_view_asset_status(self):
+        response = client.get(self.asset_status_urls)
+        self.assertEqual(response.data, {
+            'detail': 'Authentication credentials were not provided.'
+        })
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_authenticated_user_view_asset_status(self, mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.normal_user.email}
+        response = client.get(
+            self.asset_status_urls,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertIn(self.asset_status.asset_id, response.data[0].values())
+
+        self.assertEqual(len(response.data), Asset.objects.count())
+        self.assertEqual(response.status_code, 200)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_authenticated_user_view_single_asset_status(
+            self, mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.normal_user.email}
+        response = client.get(
+            '{}{}/'.format(self.asset_status_urls, self.asset_status.id),
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertIn(self.asset_status.asset_id, response.data.values())
+        self.assertEqual(response.status_code, 200)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_authenticated_user_post_asset_status(self, mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.normal_user.email}
+        data = {
+            "asset": self.test_asset.serial_number,
+            "current_status": "Available"
+        }
+        response = client.post(
+            self.asset_status_urls,
+            data=data,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertIn(data['asset'], response.data.values())
+
+        self.assertEqual(response.status_code, 201)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_authenticated_user_post_invalid_serial_number(
+            self, mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.normal_user.email}
+        data = {
+            "asset": "Invalid",
+            "current_status": "Available"
+        }
+        response = client.post(
+            self.asset_status_urls,
+            data=data,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(response.data, {
+            'asset': ['Object with serial_number=Invalid does not exist.']
+        })
+
+        self.assertEqual(response.status_code, 400)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_authenticated_user_post_invalid_status(
+            self, mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.normal_user.email}
+        data = {
+            "asset": self.test_asset.serial_number,
+            "current_status": "Invalid"
+        }
+        response = client.post(
+            self.asset_status_urls,
+            data=data,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(response.data, {
+            'current_status': ['"Invalid" is not a valid choice.']
+        })
+
+        self.assertEqual(response.status_code, 400)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_authenticated_user_post_empty_payload(self, mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.normal_user.email}
+        data = {}
+        response = client.post(
+            self.asset_status_urls,
+            data=data,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(response.data, {
+            'asset': ['This field is required.'],
+            'current_status': ['This field is required.']
+        })
+
+        self.assertEqual(response.status_code, 400)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_authenticated_user_put_not_allowed(self, mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.normal_user.email}
+        data = {}
+        response = client.put(
+            self.asset_status_urls,
+            data=data,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(response.data, {
+            'detail': 'Method "PUT" not allowed.'
+        })
+        self.assertEqual(response.status_code, 405)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_authenticated_user_patch_not_allowed(self, mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.normal_user.email}
+        data = {}
+        response = client.patch(
+            self.asset_status_urls,
+            data=data,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(response.data, {
+            'detail': 'Method "PATCH" not allowed.'
+        })
+        self.assertEqual(response.status_code, 405)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_authenticated_user_delete_not_allowed(self, mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.normal_user.email}
+        response = client.delete(
+            self.asset_status_urls,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(response.data, {
+            'detail': 'Method "DELETE" not allowed.'
+        })
+        self.assertEqual(response.status_code, 405)

--- a/api/urls.py
+++ b/api/urls.py
@@ -4,7 +4,7 @@ from django.urls import path
 
 
 from .views import UserViewSet, AssetViewSet, SecurityUserEmailsViewSet, \
-    AssetLogViewSet, UserFeedbackViewSet
+    AssetLogViewSet, UserFeedbackViewSet, AssetStatusViewSet
 
 router = SimpleRouter()
 router.register('users', UserViewSet)
@@ -13,6 +13,7 @@ router.register('security-user-emails',
                 SecurityUserEmailsViewSet, 'security-user-emails')
 router.register('asset-logs', AssetLogViewSet, 'asset-logs')
 router.register('user-feedback', UserFeedbackViewSet, 'user-feedback')
+router.register('asset-status', AssetStatusViewSet, 'asset-status')
 
 urlpatterns = [
     path('api-auth/', include('rest_framework.urls')),

--- a/api/views.py
+++ b/api/views.py
@@ -86,6 +86,6 @@ class UserFeedbackViewSet(ModelViewSet):
 class AssetStatusViewSet(ModelViewSet):
     serializer_class = AssetStatusSerializer
     queryset = AssetStatus.objects.all()
-    permission_classes = [IsAuthenticated]
-    authentication_classes = (FirebaseTokenAuthentication,)
+    permission_classes = [IsAuthenticated, ]
+    authentication_classes = [FirebaseTokenAuthentication, ]
     http_method_names = ['get', 'post']

--- a/api/views.py
+++ b/api/views.py
@@ -5,12 +5,13 @@ from rest_framework import status
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
 from rest_framework.viewsets import ModelViewSet
 from api.authentication import FirebaseTokenAuthentication
-from core.models import Asset, SecurityUser, AssetLog, UserFeedback
+from core.models import Asset, SecurityUser, AssetLog, UserFeedback, \
+    AssetStatus
 from .serializers import UserSerializer, \
     AssetSerializer, SecurityUserEmailsSerializer, \
-    AssetLogSerializer, AssetDetailSerializer, UserFeedbackSerializer
+    AssetLogSerializer, AssetDetailSerializer, UserFeedbackSerializer, \
+    AssetStatusSerializer
 from api.permissions import IsApiUser, IsSecurityUser
-
 
 User = get_user_model()
 
@@ -80,3 +81,11 @@ class UserFeedbackViewSet(ModelViewSet):
 
     def perform_create(self, serializer):
         serializer.save(reported_by=self.request.user)
+
+
+class AssetStatusViewSet(ModelViewSet):
+    serializer_class = AssetStatusSerializer
+    queryset = AssetStatus.objects.all()
+    permission_classes = [IsAuthenticated]
+    authentication_classes = (FirebaseTokenAuthentication,)
+    http_method_names = ['get', 'post']

--- a/core/admin.py
+++ b/core/admin.py
@@ -2,15 +2,16 @@ from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from .forms import UserRegistrationForm
-from .models.asset import (
-        AssetCategory, AssetType,
-        AssetSubCategory,
-        Asset,
-        AssetMake,
-        AssetLog,
-        AssetStatus,
-        AssetModelNumber,
-        AllocationHistory)
+from .models.asset import (AssetCategory,
+                           AssetType,
+                           AssetSubCategory,
+                           Asset,
+                           AssetMake,
+                           AssetLog,
+                           AssetStatus,
+                           AssetModelNumber,
+                           AllocationHistory
+                           )
 from .models.user import SecurityUser, UserFeedback
 
 User = get_user_model()
@@ -21,8 +22,7 @@ admin.site.register(
         AssetType,
         AssetSubCategory,
         AssetMake,
-        AssetModelNumber,
-        AssetLog
+        AssetModelNumber
     ]
 )
 
@@ -125,9 +125,14 @@ class AllocationHistoryAdmin(admin.ModelAdmin):
     list_display = ('asset', 'current_owner', 'previous_owner', 'created_at')
 
 
+class AssetLogsAdmin(admin.ModelAdmin):
+    list_display = ('created_at', 'asset', 'checked_by', 'log_type')
+
+
 admin.site.register(Asset, AssetAdmin)
 admin.site.register(User, UserAdmin)
 admin.site.register(SecurityUser, SecurityUserAdmin)
 admin.site.register(AssetStatus, AssetStatusAdmin)
 admin.site.register(UserFeedback, UserFeedbackAdmin)
 admin.site.register(AllocationHistory, AllocationHistoryAdmin)
+admin.site.register(AssetLog, AssetLogsAdmin)


### PR DESCRIPTION
#### What does this PR do?

Allows user to track item status via API

#### Description of Task to be completed?

- add asset status serializer
- add asset status viewset
- add test

#### How should this be manually tested?

`python manage.py test`
`/asset-status/`

#### What are the relevant pivotal tracker stories?

[#157103974](https://www.pivotaltracker.com/n/projects/2146417/stories/157103974)

#### Screenshots

![post-asset](https://user-images.githubusercontent.com/24381733/39526854-b90da452-4e28-11e8-944c-01033d5229ae.jpg)
