### PR TITLE
[#156990322] Change asset log display in admin dashboard

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -2,15 +2,16 @@ from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from .forms import UserRegistrationForm
-from .models.asset import (
-        AssetCategory, AssetType,
-        AssetSubCategory,
-        Asset,
-        AssetMake,
-        AssetLog,
-        AssetStatus,
-        AssetModelNumber,
-        AllocationHistory)
+from .models.asset import (AssetCategory,
+                           AssetType,
+                           AssetSubCategory,
+                           Asset,
+                           AssetMake,
+                           AssetLog,
+                           AssetStatus,
+                           AssetModelNumber,
+                           AllocationHistory
+                           )
 from .models.user import SecurityUser, UserFeedback
 
 User = get_user_model()
@@ -21,8 +22,7 @@ admin.site.register(
         AssetType,
         AssetSubCategory,
         AssetMake,
-        AssetModelNumber,
-        AssetLog
+        AssetModelNumber
     ]
 )
 
@@ -125,9 +125,14 @@ class AllocationHistoryAdmin(admin.ModelAdmin):
     list_display = ('asset', 'current_owner', 'previous_owner', 'created_at')
 
 
+class AssetLogsAdmin(admin.ModelAdmin):
+    list_display = ('created_at', 'asset', 'checked_by', 'log_type')
+
+
 admin.site.register(Asset, AssetAdmin)
 admin.site.register(User, UserAdmin)
 admin.site.register(SecurityUser, SecurityUserAdmin)
 admin.site.register(AssetStatus, AssetStatusAdmin)
 admin.site.register(UserFeedback, UserFeedbackAdmin)
 admin.site.register(AllocationHistory, AllocationHistoryAdmin)
+admin.site.register(AssetLog, AssetLogsAdmin)


### PR DESCRIPTION
### What does this PR do ?
Change the Asset logs on admin dashboard to make sense

### Description of work done
- add `AssetLogsAdmin` class
- add `list_display` with date, asset, checked_by, log_type columns
- add `AssetLogsAdmin` to `admin.site.register`

### How can this be manually tested ?
- Login to the admin dashboard
- click on `Asset Logs`
- you will be able to see the Asset Logs table with its columns

### Screenshots
![screen shot 2018-05-02 at 14 00 22](https://user-images.githubusercontent.com/6042152/39527758-eec14994-4e2a-11e8-86e8-3aef2ae1cf1e.png)

### Relevant PT Story
[#156990322](https://www.pivotaltracker.com/story/show/156990322)