### PR TITLE
[#157394141] user can see asset type from the API endpoint

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -39,12 +39,13 @@ class UserSerializer(serializers.ModelSerializer):
 class AssetSerializer(serializers.ModelSerializer):
     checkin_status = serializers.SerializerMethodField()
     assigned_to = UserSerializer(read_only=True)
+    asset_type = serializers.SerializerMethodField()
 
     class Meta:
         model = Asset
         fields = ("id", "asset_code", "serial_number", "model_number",
                   "checkin_status", "assigned_to", "created_at",
-                  "last_modified", "current_status"
+                  "last_modified", "current_status", 'asset_type'
                   )
 
     def get_checkin_status(self, obj):
@@ -58,6 +59,9 @@ class AssetSerializer(serializers.ModelSerializer):
                 return "checked_out"
         except AttributeError:
             return None
+
+    def get_asset_type(self, obj):
+        return obj.model_number.make_label.asset_type.asset_type
 
 
 class SecurityUserEmailsSerializer(serializers.ModelSerializer):

--- a/api/tests/test_asset_api.py
+++ b/api/tests/test_asset_api.py
@@ -8,7 +8,11 @@ from core.models import (Asset,
                          AssetModelNumber,
                          SecurityUser,
                          AssetLog,
-                         AllocationHistory)
+                         AllocationHistory,
+                         AssetMake,
+                         AssetType,
+                         AssetSubCategory,
+                         AssetCategory)
 
 User = get_user_model()
 client = APIClient()
@@ -26,18 +30,29 @@ class AssetTestCase(TestCase):
             slack_handle='@admin', password='devpassword'
         )
         self.token_other_user = 'otherusertesttoken'
-        assetmodel = AssetModelNumber(model_number="IMN50987")
-        assetmodel.save()
-        asset = Asset(
+        self.asset_category = AssetCategory.objects.create(
+            category_name="Accessories")
+        self.asset_sub_category = AssetSubCategory.objects.create(
+            sub_category_name="Sub Category name",
+            asset_category=self.asset_category)
+        self.asset_type = AssetType.objects.create(
+            asset_type="Asset Type",
+            asset_sub_category=self.asset_sub_category)
+        self.make_label = AssetMake.objects.create(
+            make_label="Asset Make", asset_type=self.asset_type)
+        self.assetmodel = AssetModelNumber(
+            model_number="IMN50987", make_label=self.make_label)
+        self.assetmodel.save()
+        self.asset = Asset(
             asset_code="IC001",
             serial_number="SN001",
             assigned_to=self.user,
-            model_number=assetmodel,
+            model_number=self.assetmodel,
         )
-        asset.save()
+        self.asset.save()
 
         allocation_history = AllocationHistory(
-            asset=asset,
+            asset=self.asset,
             current_owner=self.user
         )
 
@@ -51,7 +66,6 @@ class AssetTestCase(TestCase):
             phone_number="254720900900",
             badge_number="AE23"
         )
-        self.asset = asset
         self.asset_urls = reverse('assets-list')
 
     def test_non_authenticated_user_view_assets(self):
@@ -194,4 +208,15 @@ class AssetTestCase(TestCase):
         self.assertIn('checkin_status', response.data.keys())
         self.assertEqual(response.data['checkin_status'],
                          "checked_out")
+        self.assertEqual(response.status_code, 200)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_asset_type_in_asset_api(self, mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.user.email}
+        response = client.get(
+            '{}{}/'.format(self.asset_urls, self.asset.serial_number),
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertIn('asset_type', response.data.keys())
+        self.assertEqual(response.data['asset_type'],
+                         self.asset_type.asset_type)
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
#### What does this PR do?

Allows user to view asset type from the API endpoint

#### Description of Task to be completed?

- add `asset_type` in AssetSerializer

#### How should this be manually tested?

`python manage.py test`
`/admin/api/asset/`

#### What are the relevant pivotal tracker stories?

[#157394141](https://www.pivotaltracker.com/n/projects/2146417/stories/157394141)

#### Screenshots

![capturfiles_](https://user-images.githubusercontent.com/24381733/39803413-a1289fee-5379-11e8-8bb3-8bb0422b3852.jpg)
