### PR TITLE
feat(asset category): Create and view asset categories via API

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -119,4 +119,4 @@ class AllocationsSerializer(serializers.ModelSerializer):
 class AssetCategorySerializer(serializers.ModelSerializer):
     class Meta:
         model = AssetCategory
-        fields = ("category_name", "created_at", "last_modified")
+        fields = ("id", "category_name", "created_at", "last_modified")

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -2,7 +2,8 @@ from rest_framework import serializers
 
 from core.models import (
     User, Asset, SecurityUser, AssetLog,
-    UserFeedback, CHECKIN, CHECKOUT, AssetStatus, AllocationHistory
+    UserFeedback, CHECKIN, CHECKOUT, AssetStatus, AllocationHistory,
+    AssetCategory
 )
 
 
@@ -113,3 +114,9 @@ class AllocationsSerializer(serializers.ModelSerializer):
         model = AllocationHistory
         fields = ("asset", "current_owner", "previous_owner", "created_at")
         read_only_fields = ("previous_owner",)
+
+
+class AssetCategorySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = AssetCategory
+        fields = ("category_name", "created_at", "last_modified")

--- a/api/tests/test_asset_category_api.py
+++ b/api/tests/test_asset_category_api.py
@@ -1,0 +1,104 @@
+from django.test import TestCase
+from unittest.mock import patch
+from rest_framework.test import APIClient
+from rest_framework.reverse import reverse
+
+from core.models import User, AssetCategory
+
+client = APIClient()
+
+
+class AssetCategoryAPITest(TestCase):
+    """ Tests for the AssetCategory endpoint"""
+
+    def setUp(self):
+        self.user = User.objects.create(
+            email='testuser@gmail.com', cohort=19,
+            slack_handle='tester', password='qwerty123'
+        )
+
+        self.asset_category = AssetCategory.objects.create(
+            category_name="Accessories"
+        )
+
+        self.category_url = reverse('asset-categories-list')
+        self.token_user = 'testtoken'
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_can_post_category(self, mock_verify_token):
+        mock_verify_token.return_value = {'email': self.user.email}
+        data = {
+            "category_name": "computer"
+        }
+        response = client.post(
+            self.category_url,
+            data=data,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertIn("category_name", response.data.keys())
+        self.assertIn(data["category_name"], response.data.values())
+        self.assertEqual(response.status_code, 201)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_can_get_all_categories(self, mock_verify_token):
+        mock_verify_token.return_value = {'email': self.user.email}
+        response = client.get(
+            self.category_url,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+
+        self.assertEqual(len(response.data), AssetCategory.objects.count())
+        self.assertIn("category_name", response.data[0].keys())
+        self.assertEqual(response.status_code, 200)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_can_get_single_category(self, mock_verify_token):
+        mock_verify_token.return_value = {'email': self.user.email}
+        response = client.get(
+            f"{self.category_url}{self.asset_category.id}/",
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+
+        self.assertIn("category_name", response.data.keys())
+        self.assertIn(self.asset_category.category_name,
+                      response.data.values())
+        self.assertEqual(response.status_code, 200)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_categories_api_endpoint_cant_allow_put(self,
+                                                    mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.user.email}
+        data = {}
+        response = client.put(
+            self.category_url,
+            data=data,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(response.data, {
+            'detail': 'Method "PUT" not allowed.'
+        })
+        self.assertEqual(response.status_code, 405)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_categories_api_endpoint_cant_allow_patch(self,
+                                                      mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.user.email}
+        data = {}
+        response = client.patch(
+            self.category_url,
+            data=data,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(response.data, {
+            'detail': 'Method "PATCH" not allowed.'
+        })
+        self.assertEqual(response.status_code, 405)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_categories_api_endpoint_cant_allow_delete(self,
+                                                       mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.user.email}
+        data = {}
+        response = client.delete(
+            self.category_url,
+            data=data,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(response.data, {
+            'detail': 'Method "DELETE" not allowed.'
+        })
+        self.assertEqual(response.status_code, 405)

--- a/api/urls.py
+++ b/api/urls.py
@@ -5,7 +5,7 @@ from django.urls import path
 
 from .views import UserViewSet, AssetViewSet, SecurityUserEmailsViewSet, \
     AssetLogViewSet, UserFeedbackViewSet, AssetStatusViewSet,\
-    AllocationsViewSet
+    AllocationsViewSet, AssetCategoryViewSet
 
 router = SimpleRouter()
 router.register('users', UserViewSet)
@@ -16,6 +16,7 @@ router.register('security-user-emails',
 router.register('asset-logs', AssetLogViewSet, 'asset-logs')
 router.register('user-feedback', UserFeedbackViewSet, 'user-feedback')
 router.register('asset-status', AssetStatusViewSet, 'asset-status')
+router.register('asset-categories', AssetCategoryViewSet, 'asset-categories')
 
 urlpatterns = [
     path('api-auth/', include('rest_framework.urls')),

--- a/api/views.py
+++ b/api/views.py
@@ -99,6 +99,6 @@ class AllocationsViewSet(ModelViewSet):
 class AssetCategoryViewSet(ModelViewSet):
     serializer_class = AssetCategorySerializer
     queryset = AssetCategory.objects.all()
-    permission_classes = [IsAuthenticated]
-    authentication_classes = (FirebaseTokenAuthentication)
+    permission_classes = [IsAuthenticated, ]
+    authentication_classes = (FirebaseTokenAuthentication,)
     http_method_names = ['get', 'post']

--- a/api/views.py
+++ b/api/views.py
@@ -6,11 +6,11 @@ from rest_framework.permissions import IsAuthenticated, IsAdminUser
 from rest_framework.viewsets import ModelViewSet
 from api.authentication import FirebaseTokenAuthentication
 from core.models import Asset, SecurityUser, AssetLog, UserFeedback, \
-    AssetStatus, AllocationHistory
+    AssetStatus, AllocationHistory, AssetCategory
 from .serializers import UserSerializer, \
     AssetSerializer, SecurityUserEmailsSerializer, \
     AssetLogSerializer, UserFeedbackSerializer, \
-    AssetStatusSerializer, AllocationsSerializer
+    AssetStatusSerializer, AllocationsSerializer, AssetCategorySerializer
 from api.permissions import IsApiUser, IsSecurityUser
 
 User = get_user_model()
@@ -93,4 +93,12 @@ class AllocationsViewSet(ModelViewSet):
     queryset = AllocationHistory.objects.all()
     permission_classes = [IsAuthenticated, ]
     authentication_classes = (FirebaseTokenAuthentication,)
+    http_method_names = ['get', 'post']
+
+
+class AssetCategoryViewSet(ModelViewSet):
+    serializer_class = AssetCategorySerializer
+    queryset = AssetCategory.objects.all()
+    permission_classes = [IsAuthenticated]
+    authentication_classes = (FirebaseTokenAuthentication)
     http_method_names = ['get', 'post']


### PR DESCRIPTION
### What does this PR do?

  •Allows users to create and view asset categories via API

### Description of task to be completed:

  •add asset category endpoint
  •add asset category viewset
  •add asset category serializer

### How should this be manually tested?

  •python manage.py test
  •postman `http://127.0.0.1:8000/api/v1/asset-categories/`

### What are the relevant pivotal tracker stories?

[#157396327](https://www.pivotaltracker.com/story/show/157396327)

### Screenshots

<img width="1135" alt="screen shot 2018-05-10 at 14 55 47" src="https://user-images.githubusercontent.com/29302970/39868451-5441df12-5462-11e8-896e-5e230a0dcef3.png">
