### PR TITLE
[#157396328] user can see create and view sub categories via API

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -3,7 +3,7 @@ from rest_framework import serializers
 from core.models import (
     User, Asset, SecurityUser, AssetLog,
     UserFeedback, CHECKIN, CHECKOUT, AssetStatus, AllocationHistory,
-    AssetCategory
+    AssetCategory, AssetSubCategory
 )
 
 
@@ -84,7 +84,7 @@ class UserFeedbackSerializer(serializers.ModelSerializer):
     class Meta:
         model = UserFeedback
         fields = ("reported_by", "message", "report_type", "created_at")
-        read_only_fields = ("reported_by", )
+        read_only_fields = ("reported_by",)
 
 
 class AssetStatusSerializer(AssetSerializer):
@@ -120,3 +120,10 @@ class AssetCategorySerializer(serializers.ModelSerializer):
     class Meta:
         model = AssetCategory
         fields = ("id", "category_name", "created_at", "last_modified")
+
+
+class AssetSubCategorySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = AssetSubCategory
+        fields = ("id", "sub_category_name", "asset_category",
+                  "created_at", "last_modified")

--- a/api/tests/test_asset_sub_category_api.py
+++ b/api/tests/test_asset_sub_category_api.py
@@ -1,0 +1,115 @@
+from django.test import TestCase
+from unittest.mock import patch
+from rest_framework.test import APIClient
+from rest_framework.reverse import reverse
+
+from core.models import User, AssetCategory, AssetSubCategory
+
+client = APIClient()
+
+
+class AssetCategoryAPITest(TestCase):
+    """ Tests for the AssetCategory endpoint"""
+
+    def setUp(self):
+        self.user = User.objects.create(
+            email='testuser@gmail.com', cohort=19,
+            slack_handle='tester', password='qwerty123'
+        )
+
+        self.asset_category = AssetCategory.objects.create(
+            category_name="Accessories"
+        )
+        self.asset_sub_category = AssetSubCategory.objects.create(
+            sub_category_name="Key Board",
+            asset_category=self.asset_category
+        )
+
+        self.asset_sub_category_url = reverse('asset-sub-categories-list')
+        self.token_user = 'testtoken'
+
+    def test_non_authenticated_user_get_asset_sub_category(self):
+        response = client.get(self.asset_sub_category_url)
+        self.assertEqual(response.data, {
+            'detail': 'Authentication credentials were not provided.'
+        })
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_can_post_sub_category(self, mock_verify_token):
+        mock_verify_token.return_value = {'email': self.user.email}
+        data = {
+            "sub_category_name": "Monitor",
+            "asset_category": self.asset_category.id
+        }
+        response = client.post(
+            self.asset_sub_category_url,
+            data=data,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertIn("sub_category_name", response.data.keys())
+        self.assertIn(data["sub_category_name"], response.data.values())
+        self.assertEqual(response.status_code, 201)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_can_get_all_sub_categories(self, mock_verify_token):
+        mock_verify_token.return_value = {'email': self.user.email}
+        response = client.get(
+            self.asset_sub_category_url,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+
+        self.assertEqual(len(response.data), AssetCategory.objects.count())
+        self.assertIn("sub_category_name", response.data[0].keys())
+        self.assertEqual(response.status_code, 200)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_can_get_single_sub_category(self, mock_verify_token):
+        mock_verify_token.return_value = {'email': self.user.email}
+        response = client.get(
+            f"{self.asset_sub_category_url}{self.asset_sub_category.id}/",
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+
+        self.assertIn("sub_category_name", response.data.keys())
+        self.assertIn(self.asset_sub_category.sub_category_name,
+                      response.data.values())
+        self.assertEqual(response.status_code, 200)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_categories_api_endpoint_cant_allow_put(self,
+                                                    mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.user.email}
+        data = {}
+        response = client.put(
+            self.asset_sub_category_url,
+            data=data,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(response.data, {
+            'detail': 'Method "PUT" not allowed.'
+        })
+        self.assertEqual(response.status_code, 405)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_categories_api_endpoint_cant_allow_patch(self,
+                                                      mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.user.email}
+        data = {}
+        response = client.patch(
+            self.asset_sub_category_url,
+            data=data,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(response.data, {
+            'detail': 'Method "PATCH" not allowed.'
+        })
+        self.assertEqual(response.status_code, 405)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_categories_api_endpoint_cant_allow_delete(self,
+                                                       mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.user.email}
+        data = {}
+        response = client.delete(
+            self.asset_sub_category_url,
+            data=data,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(response.data, {
+            'detail': 'Method "DELETE" not allowed.'
+        })
+        self.assertEqual(response.status_code, 405)

--- a/api/urls.py
+++ b/api/urls.py
@@ -5,7 +5,7 @@ from django.urls import path
 
 from .views import UserViewSet, AssetViewSet, SecurityUserEmailsViewSet, \
     AssetLogViewSet, UserFeedbackViewSet, AssetStatusViewSet,\
-    AllocationsViewSet, AssetCategoryViewSet
+    AllocationsViewSet, AssetCategoryViewSet, AssetSubCategoryViewSet
 
 router = SimpleRouter()
 router.register('users', UserViewSet)
@@ -17,6 +17,8 @@ router.register('asset-logs', AssetLogViewSet, 'asset-logs')
 router.register('user-feedback', UserFeedbackViewSet, 'user-feedback')
 router.register('asset-status', AssetStatusViewSet, 'asset-status')
 router.register('asset-categories', AssetCategoryViewSet, 'asset-categories')
+router.register('asset-sub-categories', AssetSubCategoryViewSet,
+                'asset-sub-categories')
 
 urlpatterns = [
     path('api-auth/', include('rest_framework.urls')),

--- a/api/views.py
+++ b/api/views.py
@@ -6,11 +6,12 @@ from rest_framework.permissions import IsAuthenticated, IsAdminUser
 from rest_framework.viewsets import ModelViewSet
 from api.authentication import FirebaseTokenAuthentication
 from core.models import Asset, SecurityUser, AssetLog, UserFeedback, \
-    AssetStatus, AllocationHistory, AssetCategory
+    AssetStatus, AllocationHistory, AssetCategory, AssetSubCategory
 from .serializers import UserSerializer, \
     AssetSerializer, SecurityUserEmailsSerializer, \
     AssetLogSerializer, UserFeedbackSerializer, \
-    AssetStatusSerializer, AllocationsSerializer, AssetCategorySerializer
+    AssetStatusSerializer, AllocationsSerializer, AssetCategorySerializer, \
+    AssetSubCategorySerializer
 from api.permissions import IsApiUser, IsSecurityUser
 
 User = get_user_model()
@@ -49,7 +50,7 @@ class AssetViewSet(ModelViewSet):
 class SecurityUserEmailsViewSet(ModelViewSet):
     serializer_class = SecurityUserEmailsSerializer
     http_method_names = ['get']
-    permission_classes = (IsApiUser, )
+    permission_classes = (IsApiUser,)
 
     def list(self, request, *args, **kwargs):
         list_of_emails = [security_user.email
@@ -99,6 +100,14 @@ class AllocationsViewSet(ModelViewSet):
 class AssetCategoryViewSet(ModelViewSet):
     serializer_class = AssetCategorySerializer
     queryset = AssetCategory.objects.all()
+    permission_classes = [IsAuthenticated, ]
+    authentication_classes = (FirebaseTokenAuthentication,)
+    http_method_names = ['get', 'post']
+
+
+class AssetSubCategoryViewSet(ModelViewSet):
+    serializer_class = AssetSubCategorySerializer
+    queryset = AssetSubCategory.objects.all()
     permission_classes = [IsAuthenticated, ]
     authentication_classes = (FirebaseTokenAuthentication,)
     http_method_names = ['get', 'post']


### PR DESCRIPTION
#### What does this PR do?

Allows user to create and view asset sub categories via API

#### Description of Task to be completed?

- add AssetSubCategory Serializer
- add AssetSubCategory Viewset
- add test

#### How should this be manually tested?

`python manage.py test`
`/asset-sub-categories/`

#### What are the relevant pivotal tracker stories?

[#157396328](https://www.pivotaltracker.com/n/projects/2146417/stories/157396328)

#### Screenshots
![asset-sub-category](https://user-images.githubusercontent.com/24381733/39920022-4058e1fa-551e-11e8-96f4-5cb86b8db612.jpg)
![asset-sub-cat](https://user-images.githubusercontent.com/24381733/39920043-56f731aa-551e-11e8-8322-fdc7d69b6975.jpg)

