### PR TITLE
[#157396329] User can see create and view asset types via API

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -3,7 +3,7 @@ from rest_framework import serializers
 from core.models import (
     User, Asset, SecurityUser, AssetLog,
     UserFeedback, CHECKIN, CHECKOUT, AssetStatus, AllocationHistory,
-    AssetCategory, AssetSubCategory
+    AssetCategory, AssetSubCategory, AssetType
 )
 
 
@@ -126,4 +126,11 @@ class AssetSubCategorySerializer(serializers.ModelSerializer):
     class Meta:
         model = AssetSubCategory
         fields = ("id", "sub_category_name", "asset_category",
+                  "created_at", "last_modified")
+
+
+class AssetTypeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = AssetType
+        fields = ("id", "asset_type", "asset_sub_category",
                   "created_at", "last_modified")

--- a/api/tests/test_asset_type_api.py
+++ b/api/tests/test_asset_type_api.py
@@ -1,0 +1,120 @@
+from django.test import TestCase
+from unittest.mock import patch
+from rest_framework.test import APIClient
+from rest_framework.reverse import reverse
+
+from core.models import User, AssetCategory, AssetSubCategory, \
+    AssetType
+
+client = APIClient()
+
+
+class AssetCategoryAPITest(TestCase):
+    """ Tests for the AssetCategory endpoint"""
+
+    def setUp(self):
+        self.user = User.objects.create(
+            email='testuser@gmail.com', cohort=19,
+            slack_handle='tester', password='qwerty123'
+        )
+
+        self.asset_category = AssetCategory.objects.create(
+            category_name="Accessories"
+        )
+        self.asset_sub_category = AssetSubCategory.objects.create(
+            sub_category_name="Key Board",
+            asset_category=self.asset_category
+        )
+        self.asset_type = AssetType.objects.create(
+            asset_type="Dell",
+            asset_sub_category=self.asset_sub_category
+        )
+
+        self.asset_type_url = reverse('asset-types-list')
+        self.token_user = 'testtoken'
+
+    def test_non_authenticated_user_get_asset_sub_category(self):
+        response = client.get(self.asset_type_url)
+        self.assertEqual(response.data, {
+            'detail': 'Authentication credentials were not provided.'
+        })
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_can_post_asset_type(self, mock_verify_token):
+        mock_verify_token.return_value = {'email': self.user.email}
+        data = {
+            "asset_type": "Asset Type Example",
+            "asset_sub_category": self.asset_sub_category.id
+        }
+        response = client.post(
+            self.asset_type_url,
+            data=data,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertIn("asset_type", response.data.keys())
+        self.assertIn(data["asset_type"], response.data.values())
+        self.assertEqual(response.status_code, 201)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_can_get_all_asset_types(self, mock_verify_token):
+        mock_verify_token.return_value = {'email': self.user.email}
+        response = client.get(
+            self.asset_type_url,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+
+        self.assertEqual(len(response.data), AssetCategory.objects.count())
+        self.assertIn("asset_type", response.data[0].keys())
+        self.assertEqual(response.status_code, 200)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_can_get_single_asset_type(self, mock_verify_token):
+        mock_verify_token.return_value = {'email': self.user.email}
+        response = client.get(
+            f"{self.asset_type_url}{self.asset_type.id}/",
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+
+        self.assertIn("asset_type", response.data.keys())
+        self.assertIn(self.asset_type.asset_type,
+                      response.data.values())
+        self.assertEqual(response.status_code, 200)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_asset_type_api_endpoint_cant_allow_put(self,
+                                                    mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.user.email}
+        data = {}
+        response = client.put(
+            self.asset_type_url,
+            data=data,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(response.data, {
+            'detail': 'Method "PUT" not allowed.'
+        })
+        self.assertEqual(response.status_code, 405)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_asset_type_api_endpoint_cant_allow_patch(self,
+                                                      mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.user.email}
+        data = {}
+        response = client.patch(
+            self.asset_type_url,
+            data=data,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(response.data, {
+            'detail': 'Method "PATCH" not allowed.'
+        })
+        self.assertEqual(response.status_code, 405)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_asset_type_api_endpoint_cant_allow_delete(self,
+                                                       mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.user.email}
+        data = {}
+        response = client.delete(
+            self.asset_type_url,
+            data=data,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(response.data, {
+            'detail': 'Method "DELETE" not allowed.'
+        })
+        self.assertEqual(response.status_code, 405)

--- a/api/urls.py
+++ b/api/urls.py
@@ -5,7 +5,8 @@ from django.urls import path
 
 from .views import UserViewSet, AssetViewSet, SecurityUserEmailsViewSet, \
     AssetLogViewSet, UserFeedbackViewSet, AssetStatusViewSet,\
-    AllocationsViewSet, AssetCategoryViewSet, AssetSubCategoryViewSet
+    AllocationsViewSet, AssetCategoryViewSet, AssetSubCategoryViewSet, \
+    AssetTypeViewSet
 
 router = SimpleRouter()
 router.register('users', UserViewSet)
@@ -19,6 +20,8 @@ router.register('asset-status', AssetStatusViewSet, 'asset-status')
 router.register('asset-categories', AssetCategoryViewSet, 'asset-categories')
 router.register('asset-sub-categories', AssetSubCategoryViewSet,
                 'asset-sub-categories')
+router.register('asset-types', AssetTypeViewSet,
+                'asset-types')
 
 urlpatterns = [
     path('api-auth/', include('rest_framework.urls')),

--- a/api/views.py
+++ b/api/views.py
@@ -6,12 +6,13 @@ from rest_framework.permissions import IsAuthenticated, IsAdminUser
 from rest_framework.viewsets import ModelViewSet
 from api.authentication import FirebaseTokenAuthentication
 from core.models import Asset, SecurityUser, AssetLog, UserFeedback, \
-    AssetStatus, AllocationHistory, AssetCategory, AssetSubCategory
+    AssetStatus, AllocationHistory, AssetCategory, AssetSubCategory, \
+    AssetType
 from .serializers import UserSerializer, \
     AssetSerializer, SecurityUserEmailsSerializer, \
     AssetLogSerializer, UserFeedbackSerializer, \
     AssetStatusSerializer, AllocationsSerializer, AssetCategorySerializer, \
-    AssetSubCategorySerializer
+    AssetSubCategorySerializer, AssetTypeSerializer
 from api.permissions import IsApiUser, IsSecurityUser
 
 User = get_user_model()
@@ -108,6 +109,14 @@ class AssetCategoryViewSet(ModelViewSet):
 class AssetSubCategoryViewSet(ModelViewSet):
     serializer_class = AssetSubCategorySerializer
     queryset = AssetSubCategory.objects.all()
+    permission_classes = [IsAuthenticated, ]
+    authentication_classes = (FirebaseTokenAuthentication,)
+    http_method_names = ['get', 'post']
+
+
+class AssetTypeViewSet(ModelViewSet):
+    serializer_class = AssetTypeSerializer
+    queryset = AssetType.objects.all()
     permission_classes = [IsAuthenticated, ]
     authentication_classes = (FirebaseTokenAuthentication,)
     http_method_names = ['get', 'post']


### PR DESCRIPTION
#### What does this PR do?

Allows user to create and view asset type via API

#### Description of Task to be completed?

- add AssetTypes Serializer
- add AssetTypes Viewset
- add test

#### How should this be manually tested?

`python manage.py test`
`/asset-types/`

#### What are the relevant pivotal tracker stories?

[#157396329](https://www.pivotaltracker.com/n/projects/2146417/stories/157396329)

#### Screenshots
![asset-type-post](https://user-images.githubusercontent.com/24381733/39921799-ec9e870c-5524-11e8-8164-675f1ce157a2.jpg)
![asset-type-get](https://user-images.githubusercontent.com/24381733/39921822-fe8aa2e8-5524-11e8-887a-6b95877c12c0.jpg)

