### PR TITLE
[#157551217]: add api documentation

### DIFF
--- a/art/urls.py
+++ b/art/urls.py
@@ -18,14 +18,18 @@ from django.conf import settings
 from django.conf.urls import include
 from django.conf.urls.static import static
 from django.urls import path
+from rest_framework_swagger.views import get_swagger_view
 
 from api import urls
+
+schema_view = get_swagger_view(title='ART API')
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/v1/', include(urls)),
     path('jet/', include('jet.urls', 'jet')),
-    path('jet/dashboard/', include('jet.dashboard.urls', 'jet-dashboard'))
+    path('jet/dashboard/', include('jet.dashboard.urls', 'jet-dashboard')),
+    path('docs/', schema_view)
 ]
 if settings.DEBUG:
     import debug_toolbar

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ django-debug-toolbar==1.9.1
 django-dotenv==1.4.2
 django-jet==1.0.7
 django-oauth-toolkit==1.0.0
+django-rest-swagger==2.2.0
 djangorestframework==3.7.7
 docopt==0.6.2
 firebase-admin==2.9.1

--- a/settings/base.py
+++ b/settings/base.py
@@ -51,7 +51,8 @@ INSTALLED_APPS = [
     'rest_framework',
     'core',
     'api',
-    'oauth2_provider'
+    'oauth2_provider',
+    'rest_framework_swagger'
 ]
 
 AUTH_USER_MODEL = 'core.User'


### PR DESCRIPTION
#### What does this PR do?
- This PR adds documentation for the art-backend endpoints.

#### Description of Task to be completed?
- Install django-rest-swagger
- add a `/doc` path to the url file

#### How should this be manually tested?
- Locally, navigate to `http://127.0.0.1:8000/docs/`.
- Test the endpoints available here

#### Any background context you want to provide?
- The frontend developers require a doc to refer to. This addresses their program.

#### What are the relevant pivotal tracker stories?
[#157551217](https://www.pivotaltracker.com/story/show/157551217)

#### Screenshots (if appropriate)
<img width="917" alt="screen shot 2018-05-15 at 9 49 12 am" src="https://user-images.githubusercontent.com/24937734/40046638-573ab27c-5825-11e8-9a96-71c078b4da3f.png">
