### PR TITLE
Asset Condition API Endpoint

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -3,7 +3,8 @@ from rest_framework import serializers
 from core.models import (
     User, Asset, SecurityUser, AssetLog,
     UserFeedback, CHECKIN, CHECKOUT, AssetStatus, AllocationHistory,
-    AssetCategory, AssetSubCategory, AssetType, AssetModelNumber, AssetMake
+    AssetCategory, AssetSubCategory, AssetType, AssetModelNumber, AssetMake,
+    AssetCondition
 )
 
 
@@ -167,3 +168,10 @@ class AssetModelNumberSerializer(serializers.ModelSerializer):
             'make_label': make_label_instance
         })
         return internal_value
+
+
+class AssetConditionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = AssetCondition
+        fields = ("id", "asset", "asset_condition",
+                  "created_at")

--- a/api/tests/test_asset_condition_api.py
+++ b/api/tests/test_asset_condition_api.py
@@ -1,0 +1,56 @@
+from django.test import TestCase
+from unittest.mock import patch
+from rest_framework.test import APIClient
+from rest_framework.reverse import reverse
+
+from core.models import User, Asset, AssetModelNumber
+client = APIClient()
+
+
+class AssetConditionAPITest(TestCase):
+    """ Tests for the AssetCondition endpoint"""
+
+    def setUp(self):
+        self.user = User.objects.create(
+            email='testuser@gmail.com', cohort=19,
+            slack_handle='tester', password='qwerty123'
+        )
+        self.assetmodel = AssetModelNumber(
+            model_number="IMN50987", make_label=self.make_label)
+        self.asset = Asset(
+            asset_code="IC001",
+            serial_number="SN001",
+            assigned_to=self.user,
+            model_number=self.assetmodel,
+        )
+        self.asset.save()
+
+        self.condition_url = reverse('asset-condition')
+        self.token_user = 'testtoken'
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_can_post_condition(self, mock_verify_token):
+        pass
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_can_get_all_condition(self, mock_verify_token):
+        pass
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_can_get_single_condition(self, mock_verify_token):
+        pass
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_condition_api_endpoint_cant_allow_put(
+                            self, mock_verify_id_token):
+        pass
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_condition_api_endpoint_cant_allow_patch(
+                            self, mock_verify_id_token):
+        pass
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_condition_api_endpoint_cant_allow_delete(
+                            self, mock_verify_id_token):
+        pass

--- a/api/tests/test_asset_condition_api.py
+++ b/api/tests/test_asset_condition_api.py
@@ -6,10 +6,7 @@ from rest_framework.reverse import reverse
 
 from core.models import (Asset,
                          AssetModelNumber,
-                         AssetMake,
-                         AssetType,
-                         AssetSubCategory,
-                         AssetCategory)
+                         AssetCondition)
 
 User = get_user_model()
 client = APIClient()
@@ -23,53 +20,145 @@ class AssetConditionAPITest(TestCase):
             email='testuser@gmail.com', cohort=19,
             slack_handle='tester', password='qwerty123'
         )
-        self.asset_category = AssetCategory.objects.create(
-            category_name="Accessories")
-        self.asset_sub_category = AssetSubCategory.objects.create(
-            sub_category_name="Sub Category name",
-            asset_category=self.asset_category)
-        self.asset_type = AssetType.objects.create(
-            asset_type="Asset Type",
-            asset_sub_category=self.asset_sub_category)
-        self.make_label = AssetMake.objects.create(
-            make_label="Asset Make", asset_type=self.asset_type)
-        self.assetmodel = AssetModelNumber(
-            model_number="IMN50987", make_label=self.make_label)
+        self.assetmodel = AssetModelNumber(model_number="IMN50987")
         self.assetmodel.save()
-        self.asset = Asset(
+        self.token_user = 'testtoken'
+
+        self.test_asset = Asset(
             asset_code="IC001",
             serial_number="SN001",
             assigned_to=self.user,
             model_number=self.assetmodel,
         )
-        self.asset.save()
+        self.test_asset.save()
+        self.asset = Asset.objects.get(serial_number="SN001")
+        self.asset_condition = AssetCondition(
+                                    asset=self.asset,
+                                    asset_condition="working"
+                                    )
+        self.asset_condition.save()
+        self.asset_conditon = AssetCondition.objects.get(asset=self.asset)
+        # print("asset condition", self.asset_conditon)
+        self.asset_condition_urls = reverse('asset-condition-list')
 
-        self.condition_url = reverse('asset-condition-list')
-        self.token_user = 'testtoken'
-
-    @patch('api.authentication.auth.verify_id_token')
-    def test_can_post_condition(self, mock_verify_token):
-        pass
-
-    @patch('api.authentication.auth.verify_id_token')
-    def test_can_get_all_condition(self, mock_verify_token):
-        pass
-
-    @patch('api.authentication.auth.verify_id_token')
-    def test_can_get_single_condition(self, mock_verify_token):
-        pass
+    def test_non_authenciated_user_can_view_asset_condition(self):
+        response = client.get(self.asset_condition_urls)
+        self.assertEqual(response.status_code, 401)
 
     @patch('api.authentication.auth.verify_id_token')
-    def test_condition_api_endpoint_cant_allow_put(
+    def test_authenciated_user_can_view_asset_condition(
                             self, mock_verify_id_token):
-        pass
+        mock_verify_id_token.return_value = {'email': self.user.email}
+        response = client.get(
+            self.asset_condition_urls,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertIn(self.asset_condition.asset_condition,
+                      response.data[0].values())
+        self.assertEqual(len(response.data), Asset.objects.count())
+        self.assertEqual(response.status_code, 200)
 
     @patch('api.authentication.auth.verify_id_token')
-    def test_condition_api_endpoint_cant_allow_patch(
-                            self, mock_verify_id_token):
-        pass
+    def test_authenticated_user_can_post_asset_condition(self,
+                                                         mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.user.email}
+        test_asset = Asset(
+            asset_code="IC002",
+            serial_number="SN002",
+            assigned_to=self.user,
+            model_number=self.assetmodel,
+        )
+        test_asset.save()
+        data = {
+            "asset": test_asset.serial_number,
+            "asset_condition": "working perfectly"
+        }
+        response = client.post(
+            self.asset_condition_urls,
+            data=data,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertIn(data['asset_condition'], response.data.values())
+        self.assertEqual(response.status_code, 201)
 
     @patch('api.authentication.auth.verify_id_token')
-    def test_condition_api_endpoint_cant_allow_delete(
+    def test_authenticated_user_cant_post_invalid_asset_serial_number(
                             self, mock_verify_id_token):
-        pass
+        mock_verify_id_token.return_value = {'email': self.user.email}
+        invalid_asset = Asset(
+            asset_code="IC0024",
+            serial_number="SN0014",
+            assigned_to=self.user,
+            model_number=self.assetmodel,
+        )
+        data = {
+            "asset": invalid_asset,
+            "asset_condition": "working perfectly"
+        }
+        response = client.post(
+            self.asset_condition_urls,
+            data=data,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(response.status_code, 400)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_authenticated_user_can_get_all_asset_condition(
+                                self, mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.user.email}
+        response = client.get(
+                self.asset_condition_urls,
+                HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(response.status_code, 200)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_authenticated_user_can_get_single_asset_condition(
+                                    self, mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.user.email}
+        test_asset = Asset(
+            asset_code="IC002",
+            serial_number="SN002",
+            assigned_to=self.user,
+            model_number=self.assetmodel,
+        )
+        test_asset.save()
+        data = {
+            "asset": test_asset.serial_number,
+            "asset_condition": "working perfectly"
+        }
+        new_asset_condition = client.post(
+            self.asset_condition_urls,
+            data=data,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(new_asset_condition.status_code, 201)
+        response = client.get(self.asset_condition_urls, '1/',
+                              HTTP_AUTHORIZATION="Token {}"
+                              .format(self.token_user))
+        self.assertEqual(response.data, {
+             "id": '1'
+        })
+        self.assertEqual(response.status_code, 200)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_authenticated_user_condition_api_endpoint_cannot_allow_put(
+                            self, mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.user.email}
+        response = client.put(
+            self.asset_condition_urls,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(response.status_code, 405)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_authenticated_user_condition_api_endpoint_cannot_allow_patch(
+                            self, mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.user.email}
+        response = client.patch(
+            self.asset_condition_urls,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(response.status_code, 405)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_condition_api_endpoint_cannot_allow_delete(
+                            self, mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.user.email}
+        response = client.delete(
+            self.asset_condition_urls,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(response.status_code, 405)

--- a/api/tests/test_asset_condition_api.py
+++ b/api/tests/test_asset_condition_api.py
@@ -128,12 +128,11 @@ class AssetConditionAPITest(TestCase):
             data=data,
             HTTP_AUTHORIZATION="Token {}".format(self.token_user))
         self.assertEqual(new_asset_condition.status_code, 201)
-        response = client.get(self.asset_condition_urls, '1/',
-                              HTTP_AUTHORIZATION="Token {}"
-                              .format(self.token_user))
-        self.assertEqual(response.data, {
-             "id": '1'
-        })
+        response = client.get(
+            '{}{}/'.format(self.asset_condition_urls,
+                           new_asset_condition.data['id']),
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(response.data['id'], new_asset_condition.data['id'])
         self.assertEqual(response.status_code, 200)
 
     @patch('api.authentication.auth.verify_id_token')

--- a/api/tests/test_asset_condition_api.py
+++ b/api/tests/test_asset_condition_api.py
@@ -13,32 +13,31 @@ client = APIClient()
 
 
 class AssetConditionAPITest(TestCase):
-    """ Tests for the AssetCondition endpoint"""
+    ''' Tests for the AssetCondition endpoint'''
 
     def setUp(self):
         self.user = User.objects.create(
             email='testuser@gmail.com', cohort=19,
             slack_handle='tester', password='qwerty123'
         )
-        self.assetmodel = AssetModelNumber(model_number="IMN50987")
+        self.assetmodel = AssetModelNumber(model_number='IMN50987')
         self.assetmodel.save()
         self.token_user = 'testtoken'
 
         self.test_asset = Asset(
-            asset_code="IC001",
-            serial_number="SN001",
+            asset_code='IC001',
+            serial_number='SN001',
             assigned_to=self.user,
             model_number=self.assetmodel,
         )
         self.test_asset.save()
-        self.asset = Asset.objects.get(serial_number="SN001")
+        self.asset = Asset.objects.get(serial_number='SN001')
         self.asset_condition = AssetCondition(
                                     asset=self.asset,
-                                    asset_condition="working"
+                                    asset_condition='working'
                                     )
         self.asset_condition.save()
         self.asset_conditon = AssetCondition.objects.get(asset=self.asset)
-        # print("asset condition", self.asset_conditon)
         self.asset_condition_urls = reverse('asset-condition-list')
 
     def test_non_authenciated_user_can_view_asset_condition(self):
@@ -51,7 +50,7 @@ class AssetConditionAPITest(TestCase):
         mock_verify_id_token.return_value = {'email': self.user.email}
         response = client.get(
             self.asset_condition_urls,
-            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+            HTTP_AUTHORIZATION='Token {}'.format(self.token_user))
         self.assertIn(self.asset_condition.asset_condition,
                       response.data[0].values())
         self.assertEqual(len(response.data), Asset.objects.count())
@@ -62,20 +61,20 @@ class AssetConditionAPITest(TestCase):
                                                          mock_verify_id_token):
         mock_verify_id_token.return_value = {'email': self.user.email}
         test_asset = Asset(
-            asset_code="IC002",
-            serial_number="SN002",
+            asset_code='IC002',
+            serial_number='SN002',
             assigned_to=self.user,
             model_number=self.assetmodel,
         )
         test_asset.save()
         data = {
-            "asset": test_asset.serial_number,
-            "asset_condition": "working perfectly"
+            'asset': test_asset.serial_number,
+            'asset_condition': 'working perfectly'
         }
         response = client.post(
             self.asset_condition_urls,
             data=data,
-            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+            HTTP_AUTHORIZATION='Token {}'.format(self.token_user))
         self.assertIn(data['asset_condition'], response.data.values())
         self.assertEqual(response.status_code, 201)
 
@@ -84,19 +83,19 @@ class AssetConditionAPITest(TestCase):
                             self, mock_verify_id_token):
         mock_verify_id_token.return_value = {'email': self.user.email}
         invalid_asset = Asset(
-            asset_code="IC0024",
-            serial_number="SN0014",
+            asset_code='IC0024',
+            serial_number='SN0014',
             assigned_to=self.user,
             model_number=self.assetmodel,
         )
         data = {
-            "asset": invalid_asset,
-            "asset_condition": "working perfectly"
+            'asset': invalid_asset,
+            'asset_condition': 'working perfectly'
         }
         response = client.post(
             self.asset_condition_urls,
             data=data,
-            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+            HTTP_AUTHORIZATION='Token {}'.format(self.token_user))
         self.assertEqual(response.status_code, 400)
 
     @patch('api.authentication.auth.verify_id_token')
@@ -105,7 +104,7 @@ class AssetConditionAPITest(TestCase):
         mock_verify_id_token.return_value = {'email': self.user.email}
         response = client.get(
                 self.asset_condition_urls,
-                HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+                HTTP_AUTHORIZATION='Token {}'.format(self.token_user))
         self.assertEqual(response.status_code, 200)
 
     @patch('api.authentication.auth.verify_id_token')
@@ -113,25 +112,25 @@ class AssetConditionAPITest(TestCase):
                                     self, mock_verify_id_token):
         mock_verify_id_token.return_value = {'email': self.user.email}
         test_asset = Asset(
-            asset_code="IC002",
-            serial_number="SN002",
+            asset_code='IC002',
+            serial_number='SN002',
             assigned_to=self.user,
             model_number=self.assetmodel,
         )
         test_asset.save()
         data = {
-            "asset": test_asset.serial_number,
-            "asset_condition": "working perfectly"
+            'asset': test_asset.serial_number,
+            'asset_condition': 'working perfectly'
         }
         new_asset_condition = client.post(
             self.asset_condition_urls,
             data=data,
-            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+            HTTP_AUTHORIZATION='Token {}'.format(self.token_user))
         self.assertEqual(new_asset_condition.status_code, 201)
         response = client.get(
             '{}{}/'.format(self.asset_condition_urls,
                            new_asset_condition.data['id']),
-            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+            HTTP_AUTHORIZATION='Token {}'.format(self.token_user))
         self.assertEqual(response.data['id'], new_asset_condition.data['id'])
         self.assertEqual(response.status_code, 200)
 
@@ -141,7 +140,7 @@ class AssetConditionAPITest(TestCase):
         mock_verify_id_token.return_value = {'email': self.user.email}
         response = client.put(
             self.asset_condition_urls,
-            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+            HTTP_AUTHORIZATION='Token {}'.format(self.token_user))
         self.assertEqual(response.status_code, 405)
 
     @patch('api.authentication.auth.verify_id_token')
@@ -150,7 +149,7 @@ class AssetConditionAPITest(TestCase):
         mock_verify_id_token.return_value = {'email': self.user.email}
         response = client.patch(
             self.asset_condition_urls,
-            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+            HTTP_AUTHORIZATION='Token {}'.format(self.token_user))
         self.assertEqual(response.status_code, 405)
 
     @patch('api.authentication.auth.verify_id_token')
@@ -159,5 +158,5 @@ class AssetConditionAPITest(TestCase):
         mock_verify_id_token.return_value = {'email': self.user.email}
         response = client.delete(
             self.asset_condition_urls,
-            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+            HTTP_AUTHORIZATION='Token {}'.format(self.token_user))
         self.assertEqual(response.status_code, 405)

--- a/api/tests/test_asset_condition_api.py
+++ b/api/tests/test_asset_condition_api.py
@@ -1,9 +1,17 @@
 from django.test import TestCase
 from unittest.mock import patch
+from django.contrib.auth import get_user_model
 from rest_framework.test import APIClient
 from rest_framework.reverse import reverse
 
-from core.models import User, Asset, AssetModelNumber
+from core.models import (Asset,
+                         AssetModelNumber,
+                         AssetMake,
+                         AssetType,
+                         AssetSubCategory,
+                         AssetCategory)
+
+User = get_user_model()
 client = APIClient()
 
 
@@ -15,8 +23,19 @@ class AssetConditionAPITest(TestCase):
             email='testuser@gmail.com', cohort=19,
             slack_handle='tester', password='qwerty123'
         )
+        self.asset_category = AssetCategory.objects.create(
+            category_name="Accessories")
+        self.asset_sub_category = AssetSubCategory.objects.create(
+            sub_category_name="Sub Category name",
+            asset_category=self.asset_category)
+        self.asset_type = AssetType.objects.create(
+            asset_type="Asset Type",
+            asset_sub_category=self.asset_sub_category)
+        self.make_label = AssetMake.objects.create(
+            make_label="Asset Make", asset_type=self.asset_type)
         self.assetmodel = AssetModelNumber(
             model_number="IMN50987", make_label=self.make_label)
+        self.assetmodel.save()
         self.asset = Asset(
             asset_code="IC001",
             serial_number="SN001",
@@ -25,7 +44,7 @@ class AssetConditionAPITest(TestCase):
         )
         self.asset.save()
 
-        self.condition_url = reverse('asset-condition')
+        self.condition_url = reverse('asset-condition-list')
         self.token_user = 'testtoken'
 
     @patch('api.authentication.auth.verify_id_token')

--- a/api/tests/test_asset_condition_api.py
+++ b/api/tests/test_asset_condition_api.py
@@ -18,7 +18,7 @@ class AssetConditionAPITest(TestCase):
     def setUp(self):
         self.user = User.objects.create(
             email='testuser@gmail.com', cohort=19,
-            slack_handle='tester', password='qwerty1234'
+            slack_handle='tester', password='qwerty12345'
         )
         self.assetmodel = AssetModelNumber(model_number='IMN50987')
         self.assetmodel.save()

--- a/api/tests/test_asset_condition_api.py
+++ b/api/tests/test_asset_condition_api.py
@@ -18,7 +18,7 @@ class AssetConditionAPITest(TestCase):
     def setUp(self):
         self.user = User.objects.create(
             email='testuser@gmail.com', cohort=19,
-            slack_handle='tester', password='qwerty123'
+            slack_handle='tester', password='qwerty1234'
         )
         self.assetmodel = AssetModelNumber(model_number='IMN50987')
         self.assetmodel.save()

--- a/api/urls.py
+++ b/api/urls.py
@@ -6,7 +6,7 @@ from django.urls import path
 from .views import UserViewSet, AssetViewSet, SecurityUserEmailsViewSet, \
     AssetLogViewSet, UserFeedbackViewSet, AssetStatusViewSet,\
     AllocationsViewSet, AssetCategoryViewSet, AssetSubCategoryViewSet, \
-    AssetTypeViewSet, AssetModelNumberViewSet
+    AssetTypeViewSet, AssetModelNumberViewSet, AssetConditionViewSet
 
 router = SimpleRouter()
 router.register('users', UserViewSet)
@@ -24,6 +24,9 @@ router.register('asset-types', AssetTypeViewSet,
                 'asset-types')
 router.register('asset-models', AssetModelNumberViewSet,
                 'asset-models')
+router.register('asset-condition', AssetConditionViewSet,
+                'asset-condition')
+
 
 urlpatterns = [
     path('api-auth/', include('rest_framework.urls')),

--- a/api/views.py
+++ b/api/views.py
@@ -7,13 +7,13 @@ from rest_framework.viewsets import ModelViewSet
 from api.authentication import FirebaseTokenAuthentication
 from core.models import Asset, SecurityUser, AssetLog, UserFeedback, \
     AssetStatus, AllocationHistory, AssetCategory, AssetSubCategory, \
-    AssetType, AssetModelNumber
+    AssetType, AssetModelNumber, AssetCondition
 from .serializers import UserSerializer, \
     AssetSerializer, SecurityUserEmailsSerializer, \
     AssetLogSerializer, UserFeedbackSerializer, \
     AssetStatusSerializer, AllocationsSerializer, AssetCategorySerializer, \
     AssetSubCategorySerializer, AssetTypeSerializer, \
-    AssetModelNumberSerializer
+    AssetModelNumberSerializer, AssetConditionSerializer
 from api.permissions import IsApiUser, IsSecurityUser
 
 User = get_user_model()
@@ -131,4 +131,12 @@ class AssetModelNumberViewSet(ModelViewSet):
     queryset = AssetModelNumber.objects.all()
     permission_classes = [IsAuthenticated, ]
     authentication_classes = [FirebaseTokenAuthentication, ]
+    http_method_names = ['get', 'post']
+
+
+class AssetConditionViewSet(ModelViewSet):
+    serializer_class = AssetConditionSerializer
+    queryset = AssetCondition.objects.all()
+    permission_classes = [IsAuthenticated, ]
+    authentication_classes = (FirebaseTokenAuthentication, )
     http_method_names = ['get', 'post']


### PR DESCRIPTION
#### What does this PR do?
This pull request introduces adding and Asset condition via the API

####  Description of Task to be completed?
This should be possible:
Add notes on the asset condition via API
I should see all asset condition notes 
I should see a single asset condition using asset condition id

####  How should this be manually tested?
python manage.py test

####  Any background context you want to provide?
User could not be able to write notes on the condition of the asset via the API.

####  What are the relevant pivotal tracker stories?
#157183399
