### PR TITLE
feat(admin view assets): Admin can view all assets via API

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -35,7 +35,10 @@ class AssetViewSet(ModelViewSet):
 
     def get_queryset(self):
         user = self.request.user
-        return Asset.objects.filter(assigned_to=user)
+        is_admin = self.request.user.is_staff
+        if not is_admin:
+            return Asset.objects.filter(assigned_to=user)
+        return Asset.objects.all()
 
     def get_object(self):
         queryset = Asset.objects.all()
@@ -43,7 +46,7 @@ class AssetViewSet(ModelViewSet):
         return obj
 
     def perform_create(self, serializer):
-            serializer.save()
+        serializer.save()
 
 
 class SecurityUserEmailsViewSet(ModelViewSet):


### PR DESCRIPTION
### What does this PR do?
• Allow admin to view all assets via API

### Description of tasks to be completed
• Add functionality to allow admin to view all assets
• Add tests

### How should this be manually tested? 
• `python manage.py test`
• Using this URL `http://127.0.0.1:8000/api/v1/assets/` on Postman. Use a Superuser token to view all assets

### What are the relevant pivotal tracker stories
• [#157682134](https://www.pivotaltracker.com/story/show/157682134)

### Screenshots
Admin User Token

<img width="1374" alt="screen shot 2018-05-21 at 17 51 41" src="https://user-images.githubusercontent.com/15943349/40313952-b6e9d6ae-5d1f-11e8-9aa2-b26e16eed38d.png">

User Token

<img width="1377" alt="screen shot 2018-05-21 at 17 51 56" src="https://user-images.githubusercontent.com/15943349/40313956-b719724c-5d1f-11e8-9b1c-c29ce698592c.png">
