### PR TITLE
chore(documentation): Add api documentation

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -1,6 +1,8 @@
 from rest_framework.routers import SimpleRouter
 from django.conf.urls import include
 from django.urls import path
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
 
 
 from .views import UserViewSet, AssetViewSet, SecurityUserEmailsViewSet, \
@@ -8,6 +10,17 @@ from .views import UserViewSet, AssetViewSet, SecurityUserEmailsViewSet, \
     AllocationsViewSet, AssetCategoryViewSet, AssetSubCategoryViewSet, \
     AssetTypeViewSet, AssetModelNumberViewSet, AssetConditionViewSet, \
     AssetMakeViewSet
+
+
+schema_view = get_schema_view(
+    openapi.Info(
+        title='ART API',
+        default_version='v1',
+        description='Assset tracking',
+        license=openapi.License(name='BSD License'),
+    ),
+    public=True,
+)
 
 router = SimpleRouter()
 router.register('users', UserViewSet)
@@ -31,7 +44,9 @@ router.register('asset-makes', AssetMakeViewSet, 'asset-makes')
 
 urlpatterns = [
     path('api-auth/', include('rest_framework.urls')),
-    path('o/', include('oauth2_provider.urls', namespace='oauth2_provider'))
+    path('o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
+    path('docs/', schema_view.with_ui('redoc',
+                                      cache_timeout=None), name='schema-redoc')
 ]
 
 urlpatterns += router.urls

--- a/art/urls.py
+++ b/art/urls.py
@@ -18,19 +18,16 @@ from django.conf import settings
 from django.conf.urls import include
 from django.conf.urls.static import static
 from django.urls import path
-from rest_framework_swagger.views import get_swagger_view
 
 from api import urls
-
-schema_view = get_swagger_view(title='ART API')
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/v1/', include(urls)),
     path('jet/', include('jet.urls', 'jet')),
     path('jet/dashboard/', include('jet.dashboard.urls', 'jet-dashboard')),
-    path('docs/', schema_view)
 ]
+
 if settings.DEBUG:
     import debug_toolbar
     urlpatterns += [

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ django-debug-toolbar==1.9.1
 django-dotenv==1.4.2
 django-jet==1.0.7
 django-oauth-toolkit==1.0.0
-django-rest-swagger==2.2.0
+drf-yasg==1.7.4
 djangorestframework==3.7.7
 docopt==0.6.2
 firebase-admin==2.9.1

--- a/settings/base.py
+++ b/settings/base.py
@@ -52,7 +52,7 @@ INSTALLED_APPS = [
     'core',
     'api',
     'oauth2_provider',
-    'rest_framework_swagger'
+    'drf_yasg'
 ]
 
 AUTH_USER_MODEL = 'core.User'
@@ -190,3 +190,17 @@ LOGGING = {
 csv = Csv(cast=lambda s: tuple(s.split(':')))
 
 ADMINS = csv(os.environ.get('ADMINS', ''))
+
+SWAGGER_SETTINGS = {
+    'SECURITY_DEFINITIONS': {
+        'api_key': {
+            'type': 'apiKey',
+            'in': 'header',
+            'name': 'Authorization'
+        }
+    },
+}
+
+REDOC_SETTINGS = {
+    'LAZY_RENDERING': True,
+}


### PR DESCRIPTION
 ### What does this PR do?

This PR adds documentation for the art-backend endpoints.

### Description of Task to be completed?

  •Install django-rest-swagger
  •Add a /doc path to the url file

How should this be manually tested?

  •Locally, navigate to` http://127.0.0.1:8000/docs/`
  •Test the endpoints available here

Any background context you want to provide?

The frontend developers require a doc to refer to. This addresses their program.

What are the relevant pivotal tracker stories?

[#157681976](https://www.pivotaltracker.com/story/show/157681976)

Screenshots (if appropriate)
<img width="1440" alt="screen shot 2018-05-21 at 18 46 06" src="https://user-images.githubusercontent.com/29302970/40316545-574111b0-5d27-11e8-9c07-875149936108.png">

