### PR TITLE
#157394192: show asset model number instead of id

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -42,6 +42,10 @@ class AssetSerializer(serializers.ModelSerializer):
     checkin_status = serializers.SerializerMethodField()
     assigned_to = UserSerializer(read_only=True)
     asset_type = serializers.SerializerMethodField()
+    model_number = serializers.SlugRelatedField(
+        queryset=AssetModelNumber.objects.all(),
+        slug_field="model_number"
+    )
 
     class Meta:
         model = Asset

--- a/api/tests/test_asset_api.py
+++ b/api/tests/test_asset_api.py
@@ -113,7 +113,7 @@ class AssetTestCase(TestCase):
         data = {
             "asset_code": "IC002",
             "serial_number": "SN002",
-            "model_number": self.assetmodel.id,
+            "model_number": self.assetmodel.model_number,
         }
         response = client.post(
             self.asset_urls,
@@ -146,7 +146,7 @@ class AssetTestCase(TestCase):
             data=data,
             HTTP_AUTHORIZATION="Token {}".format(self.token_user))
         self.assertEqual(response.data, {
-            'model_number': ['Invalid pk "300" - object does not exist.']
+            'model_number': ['Object with model_number=300 does not exist.']
         })
         self.assertEqual(response.status_code, 400)
 


### PR DESCRIPTION
#### What does this PR do?
- Asset model number should be displayed instead of ID on the API endpoint

#### Description of task to be completed:
- Add serializer for model_number on AssetSerializer
- FIx test

#### How can this be manually tested?
- python manage.py test
- /api/v1/assets/

#### Relevan Pivotal Tracker Stories
- #157394192

#### Screenshots

**Before**
<img width="948" alt="screen shot 2018-05-23 at 8 59 51 am" src="https://user-images.githubusercontent.com/28709038/40486734-03cb395e-5f5a-11e8-86a8-104702f94b02.png">

**After**
<img width="948" alt="screen shot 2018-05-23 at 9 00 38 am" src="https://user-images.githubusercontent.com/28709038/40486740-090f7100-5f5a-11e8-85df-279d93a2197f.png">


