### PR TITLE
[#157183397] Implement user can view total asset by current status

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -213,3 +213,22 @@ class AssetIncidentReportSerializer(serializers.ModelSerializer):
         fields = ('id', 'asset', 'incident_type', 'incident_location',
                   'incident_description', 'injuries_sustained',
                   'loss_of_property', 'witnesses', 'police_abstract_obtained')
+
+
+class AssetHealthSerializer(serializers.ModelSerializer):
+    asset_type = serializers.SerializerMethodField()
+    model_number = serializers.SerializerMethodField()
+    count_by_status = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Asset
+        fields = ('asset_type', 'model_number', 'count_by_status', )
+
+    def get_asset_type(self, obj):
+        return obj.model_number.make_label.asset_type.asset_type
+
+    def get_count_by_status(self, obj):
+        return obj.current_status
+
+    def get_model_number(self, obj):
+        return obj.model_number.model_number

--- a/api/tests/test_asset_health_api.py
+++ b/api/tests/test_asset_health_api.py
@@ -1,0 +1,140 @@
+from unittest.mock import patch
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from rest_framework.reverse import reverse
+from rest_framework.test import APIClient
+
+from core.models import (Asset,
+                         AssetModelNumber,
+                         AllocationHistory,
+                         AssetMake,
+                         AssetType,
+                         AssetSubCategory,
+                         AssetCategory)
+
+User = get_user_model()
+client = APIClient()
+
+
+class AssetHealthTestCase(TestCase):
+    def setUp(self):
+        self.admin = User.objects.create_superuser(
+            email='admin@site.com', cohort=20,
+            slack_handle='@admin', password='devpassword'
+        )
+        self.token_admin = "tokenadmin"
+        self.user = User.objects.create_user(
+            email='user@site.com', cohort=20,
+            slack_handle='@admin', password='devpassword'
+        )
+        self.token_user = 'testtoken'
+        self.other_user = User.objects.create_user(
+            email='user1@site.com', cohort=20,
+            slack_handle='@admin', password='devpassword'
+        )
+        self.token_other_user = 'otherusertesttoken'
+        self.asset_category = AssetCategory.objects.create(
+            category_name="Accessories")
+        self.asset_sub_category = AssetSubCategory.objects.create(
+            sub_category_name="Sub Category name",
+            asset_category=self.asset_category)
+        self.asset_type = AssetType.objects.create(
+            asset_type="Asset Type",
+            asset_sub_category=self.asset_sub_category)
+        self.make_label = AssetMake.objects.create(
+            make_label="Asset Make", asset_type=self.asset_type)
+        self.assetmodel = AssetModelNumber(
+            model_number="IMN50987", make_label=self.make_label)
+        self.assetmodel.save()
+        self.asset = Asset(
+            asset_code="IC001",
+            serial_number="SN001",
+            assigned_to=self.user,
+            model_number=self.assetmodel,
+        )
+        self.asset.save()
+
+        allocation_history = AllocationHistory(
+            asset=self.asset,
+            current_owner=self.user
+        )
+
+        allocation_history.save()
+
+        self.asset_urls = reverse('asset-health-list')
+
+    def test_non_authenticated_user_view_assets_health(self):
+        response = client.get(self.asset_urls)
+        self.assertEqual(response.data, {
+            'detail': 'Authentication credentials were not provided.'
+        })
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_non_admin_cannot_view_asset_health(self, mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.user.email}
+        response = client.get(
+            self.asset_urls,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(response.data,
+                         {'detail': ['You do not have authorization']})
+        self.assertEqual(response.status_code, 403)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_authenticated_admin_view_assets_health(self,
+                                                    mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.admin.email}
+        response = client.get(
+            self.asset_urls,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_admin))
+        self.assertEqual(len(response.data), Asset.objects.count())
+        self.assertEqual(response.data[0]['model_number'],
+                         self.asset.model_number.model_number)
+        self.assertEqual(response.data[0]['count_by_status']['Allocated'], 1)
+        self.assertEqual(response.data[0]['count_by_status']['Available'], 0)
+        self.assertEqual(response.data[0]['count_by_status']['Damaged'], 0)
+        self.assertEqual(response.data[0]['count_by_status']['Lost'], 0)
+        self.assertEqual(response.status_code, 200)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_assets_health_api_endpoint_cant_allow_put(self,
+                                                       mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.user.email}
+        response = client.put(
+            self.asset_urls,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(response.data, {
+            'detail': 'Method "PUT" not allowed.'
+        })
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_assets_health_api_endpoint_cant_allow_patch(self,
+                                                         mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.user.email}
+        response = client.patch(
+            self.asset_urls,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(response.data, {
+            'detail': 'Method "PATCH" not allowed.'
+        })
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_assets_health__endpoint_cant_allow_delete(self,
+                                                       mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.user.email}
+        response = client.delete(
+            '{}{}/'.format(self.asset_urls, self.asset.serial_number),
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(response.data, {
+            'detail': 'Method "DELETE" not allowed.'
+        })
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_asset_type_in_asset_health_api(self, mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.admin.email}
+        response = client.get(
+            self.asset_urls,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_admin))
+        self.assertIn('asset_type', response.data[0])
+        self.assertEqual(response.data[0]['asset_type'],
+                         self.asset_type.asset_type)
+        self.assertEqual(response.status_code, 200)

--- a/api/urls.py
+++ b/api/urls.py
@@ -9,7 +9,7 @@ from .views import UserViewSet, AssetViewSet, SecurityUserEmailsViewSet, \
     AssetLogViewSet, UserFeedbackViewSet, AssetStatusViewSet,\
     AllocationsViewSet, AssetCategoryViewSet, AssetSubCategoryViewSet, \
     AssetTypeViewSet, AssetModelNumberViewSet, AssetConditionViewSet, \
-    AssetMakeViewSet, AssetIncidentReportViewSet
+    AssetMakeViewSet, AssetIncidentReportViewSet, AssetHealthCountViewSet
 
 
 schema_view = get_schema_view(
@@ -43,6 +43,7 @@ router.register('asset-condition', AssetConditionViewSet,
 router.register('asset-makes', AssetMakeViewSet, 'asset-makes')
 router.register('incidence-reports', AssetIncidentReportViewSet,
                 'incidence-reports')
+router.register('asset-health', AssetHealthCountViewSet, 'asset-health')
 
 urlpatterns = [
     path('api-auth/', include('rest_framework.urls')),


### PR DESCRIPTION
#### What does this PR do?
- Allows the admin to view the number of assets for each status of particular asset type and 
 model
#### Description of Task to be completed?
- add test
- add  AssetHeathSerializer class
- add AssetHealthCountViewSet 
#### How should this be manually tested?
python manage.py test

#### Screenshot 
- 
<img width="961" alt="screen shot 2018-05-30 at 4 08 20 pm" src="https://user-images.githubusercontent.com/16616203/40729270-eed5e2fa-6423-11e8-9d77-14dbb97986c3.png">
<img width="953" alt="screen shot 2018-05-30 at 4 08 42 pm" src="https://user-images.githubusercontent.com/16616203/40729311-00ae4076-6424-11e8-95b9-1be17cb5fc48.png">


#### What are the relevant pivotal tracker stories?
- #157183397