### PR TITLE
[#157912326] Admin can add security user via API

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -222,7 +222,7 @@ class AssetHealthSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Asset
-        fields = ('asset_type', 'model_number', 'count_by_status', )
+        fields = ('asset_type', 'model_number', 'count_by_status',)
 
     def get_asset_type(self, obj):
         return obj.model_number.make_label.asset_type.asset_type
@@ -232,3 +232,19 @@ class AssetHealthSerializer(serializers.ModelSerializer):
 
     def get_model_number(self, obj):
         return obj.model_number.model_number
+
+
+class SecurityUserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SecurityUser
+        fields = (
+            'id', 'first_name', 'last_name', 'email',
+            'badge_number', 'phone_number', 'last_modified',
+            'date_joined', 'last_login'
+        )
+
+        extra_kwargs = {
+            'last_modified': {'read_only': True},
+            'date_joined': {'read_only': True},
+            'last_login': {'read_only': True}
+        }

--- a/api/tests/test_security_user.py
+++ b/api/tests/test_security_user.py
@@ -1,4 +1,6 @@
 import json
+from unittest.mock import patch
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 from rest_framework.reverse import reverse
 from rest_framework.test import APIClient
@@ -6,11 +8,24 @@ from rest_framework.test import APIClient
 from core.models import SecurityUser, APIUser
 
 client = APIClient()
+User = get_user_model()
 
 
 class SecurityUserTestCase(TestCase):
     def setUp(self):
         self.security_users_url = reverse('security-user-emails-list')
+        self.security_users_admin_url = reverse('security-users-list')
+
+        self.user = User.objects.create(
+            email='test@site.com', cohort=20,
+            slack_handle='@test_user', password='devpassword'
+        )
+        self.token_user = 'testtoken'
+        self.admin_user = User.objects.create_superuser(
+            email='admin@site.com', cohort=20,
+            slack_handle='@admin', password='devpassword'
+        )
+        self.token_admin = 'admintesttoken'
 
         SecurityUser.objects.create(
             email="sectest1@andela.com",
@@ -65,3 +80,84 @@ class SecurityUserTestCase(TestCase):
         self.assertEqual(response.status_code, 401)
         self.assertIn(json.loads(response.content)["detail"],
                       'Authentication credentials were not provided.')
+
+    def test_non_authenticated_user_view_security_user_api_endpoint(self):
+        response = client.get(self.security_users_admin_url)
+        self.assertEqual(response.data, {
+            'detail': 'Authentication credentials were not provided.'
+        })
+        self.assertEqual(response.status_code, 401)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_non_admin_user_can_view_security_user_api_endpoint(
+            self, mock_verify_token):
+        mock_verify_token.return_value = {'email': self.user.email}
+        response = client.get(
+            self.security_users_admin_url,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(response.data, {
+            'detail': 'You do not have permission to perform this action.'
+        })
+        self.assertEqual(response.status_code, 403)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_admin_user_add_security_users_from_api_endpoint(
+            self, mock_verify_token):
+        mock_verify_token.return_value = {'email': self.admin_user.email}
+        users_count_before = User.objects.count()
+        data = {
+            "email": "security@mail.com",
+            "badge_number": "B-A-D-G-E-N-O",
+        }
+        response = client.post(
+            self.security_users_admin_url,
+            data=data,
+            format='json',
+            HTTP_AUTHORIZATION="Token {}".format(self.token_admin))
+        users_count_after = User.objects.count()
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(users_count_after, users_count_before + 1)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_admin_user_view_security_users_from_api_endpoint(
+            self, mock_verify_token):
+        mock_verify_token.return_value = {'email': self.admin_user.email}
+        response = client.get(
+            self.security_users_admin_url,
+            format='json',
+            HTTP_AUTHORIZATION="Token {}".format(self.token_admin))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), SecurityUser.objects.count())
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_security_user_api_endpoint_cant_allow_put(
+            self, mock_verify_token):
+        mock_verify_token.return_value = {'email': self.admin_user.email}
+        response = client.put(
+            self.security_users_admin_url,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_admin))
+        self.assertEqual(response.data, {
+            'detail': 'Method "PUT" not allowed.'
+        })
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_security_user_api_endpoint_cant_allow_patch(
+            self, mock_verify_token):
+        mock_verify_token.return_value = {'email': self.admin_user.email}
+        response = client.patch(
+            self.security_users_admin_url,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_admin))
+        self.assertEqual(response.data, {
+            'detail': 'Method "PATCH" not allowed.'
+        })
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_security_user_api_endpoint_cant_allow_delete(
+            self, mock_verify_token):
+        mock_verify_token.return_value = {'email': self.admin_user.email}
+        response = client.delete(
+            self.security_users_admin_url,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_admin))
+        self.assertEqual(response.data, {
+            'detail': 'Method "DELETE" not allowed.'
+        })

--- a/api/urls.py
+++ b/api/urls.py
@@ -9,7 +9,8 @@ from .views import UserViewSet, AssetViewSet, SecurityUserEmailsViewSet, \
     AssetLogViewSet, UserFeedbackViewSet, AssetStatusViewSet,\
     AllocationsViewSet, AssetCategoryViewSet, AssetSubCategoryViewSet, \
     AssetTypeViewSet, AssetModelNumberViewSet, AssetConditionViewSet, \
-    AssetMakeViewSet, AssetIncidentReportViewSet, AssetHealthCountViewSet
+    AssetMakeViewSet, AssetIncidentReportViewSet, AssetHealthCountViewSet,\
+    SecurityUserViewSet
 
 
 schema_view = get_schema_view(
@@ -44,6 +45,8 @@ router.register('asset-makes', AssetMakeViewSet, 'asset-makes')
 router.register('incidence-reports', AssetIncidentReportViewSet,
                 'incidence-reports')
 router.register('asset-health', AssetHealthCountViewSet, 'asset-health')
+router.register('security-users', SecurityUserViewSet,
+                'security-users')
 
 urlpatterns = [
     path('api-auth/', include('rest_framework.urls')),

--- a/api/views.py
+++ b/api/views.py
@@ -17,7 +17,7 @@ from .serializers import UserSerializer, \
     AssetSubCategorySerializer, AssetTypeSerializer, \
     AssetModelNumberSerializer, AssetConditionSerializer, \
     AssetMakeSerializer, AssetIncidentReportSerializer, \
-    AssetHealthSerializer
+    AssetHealthSerializer, SecurityUserSerializer
 from api.permissions import IsApiUser, IsSecurityUser
 
 User = get_user_model()
@@ -147,7 +147,7 @@ class AssetConditionViewSet(ModelViewSet):
     serializer_class = AssetConditionSerializer
     queryset = AssetCondition.objects.all()
     permission_classes = [IsAuthenticated, ]
-    authentication_classes = (FirebaseTokenAuthentication, )
+    authentication_classes = (FirebaseTokenAuthentication,)
     http_method_names = ['get', 'post']
 
 
@@ -218,3 +218,11 @@ class AssetHealthCountViewSet(ModelViewSet):
             return Response(asset_list)
         return Response(exception=True, status=403,
                         data={'detail': ['You do not have authorization']})
+
+
+class SecurityUserViewSet(ModelViewSet):
+    serializer_class = SecurityUserSerializer
+    queryset = SecurityUser.objects.all()
+    permission_classes = [IsAuthenticated, IsAdminUser]
+    authentication_classes = [FirebaseTokenAuthentication, ]
+    http_method_names = ['get', 'post']


### PR DESCRIPTION
### What does this PR do?

  Allows an admin to create a security user via API

### Description of task to be completed:

- Add SecurityUser Serializer
- Add SecurityUser ViewSet
- Add test

### How can this be manually tested?

- `python manage.py test`
-  `/security-users/`

### Screenshot
![secuser](https://user-images.githubusercontent.com/24381733/40774699-f63547e2-64ce-11e8-9026-9bb1e61f1535.jpg)


#### What are the relevant pivotal tracker stories?

[ #157912326](https://www.pivotaltracker.com/n/projects/2146417/stories/157912326)


