### PR TITLE
#157426958 Implements asset filter by email address

### DIFF
--- a/api/tests/test_asset_api.py
+++ b/api/tests/test_asset_api.py
@@ -256,3 +256,32 @@ class AssetTestCase(TestCase):
         self.assertEqual(response.data['asset_type'],
                          self.asset_type.asset_type)
         self.assertEqual(response.status_code, 200)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_asset_filter_by_email(self, mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.user.email}
+        response = client.get(
+            '{}?email={}'.format(self.asset_urls, self.user.email),
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertTrue(len(response.data) > 0)
+        self.assertIn(self.user.email,
+                      response.data[0]['assigned_to']['email'])
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_asset_filter_non_existing_email_return_empty(
+            self, mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.user.email}
+        response = client.get(
+            '{}?email={}'.format(self.asset_urls, 'userwithnoasset@site.com'),
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertFalse(len(response.data) > 0)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_asset_filter_with_invalid_email_fails_with_validation_error(
+            self, mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.user.email}
+        response = client.get(
+            '{}?email={}'.format(self.asset_urls, 'notavalidemail'),
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data[0], 'Enter a valid email address.')


### PR DESCRIPTION
## What does this PR do?
Implement asset filtering/searching by user email address

## Description of task to be completed
- adds support for email filter via 'email' query param
- test asset filtering with email

## How can this be manually tested?
- python manage.py test
- /api/v1/assets?email=[email_address]

## What are the relevant pivotal tracker stories?
[#157426958](https://www.pivotaltracker.com/story/show/157426958)

## ScreenShot
<img width="1058" alt="screen shot 2018-06-03 at 8 01 46 pm" src="https://user-images.githubusercontent.com/31279497/40890130-10bf5ec6-6769-11e8-9c64-73d78fbe9a05.png">
<img width="810" alt="screen shot 2018-06-03 at 7 59 17 pm" src="https://user-images.githubusercontent.com/31279497/40890133-164913be-6769-11e8-9370-2f762204fc98.png">
<img width="542" alt="screen shot 2018-06-03 at 8 00 17 pm" src="https://user-images.githubusercontent.com/31279497/40890136-17d6eb0c-6769-11e8-95e3-b06f5515ba0b.png">
