### PR TITLE
[#157353629] User can see allocation logs for a specific asset

### DIFF
--- a/api/tests/test_asset_api.py
+++ b/api/tests/test_asset_api.py
@@ -285,3 +285,13 @@ class AssetTestCase(TestCase):
             HTTP_AUTHORIZATION="Token {}".format(self.token_user))
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.data[0], 'Enter a valid email address.')
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_assets_have_allocation_history(
+            self, mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.user.email}
+        response = client.get(
+            '{}{}/'.format(self.asset_urls, self.asset.serial_number),
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertIn('allocation_history', response.data.keys())
+        self.assertEqual(response.status_code, 200)

--- a/api/views.py
+++ b/api/views.py
@@ -117,12 +117,6 @@ class AllocationsViewSet(ModelViewSet):
     http_method_names = ['get', 'post']
 
 
-    def get_queryset(self):
-          
-        if 'pk' in self.kwargs:
-            return AllocationHistory.objects.filter(asset=self.kwargs['pk'])
-        return AllocationHistory.objects.all()
-
 class AssetCategoryViewSet(ModelViewSet):
     serializer_class = AssetCategorySerializer
     queryset = AssetCategory.objects.all()

--- a/api/views.py
+++ b/api/views.py
@@ -117,6 +117,12 @@ class AllocationsViewSet(ModelViewSet):
     http_method_names = ['get', 'post']
 
 
+    def get_queryset(self):
+          
+        if 'pk' in self.kwargs:
+            return AllocationHistory.objects.filter(asset=self.kwargs['pk'])
+        return AllocationHistory.objects.all()
+
 class AssetCategoryViewSet(ModelViewSet):
     serializer_class = AssetCategorySerializer
     queryset = AssetCategory.objects.all()


### PR DESCRIPTION
### What does this PR do?

  Allows users to see allocation logs for a specific asset

### Description of task to be completed:

- Add allocation history serializer method field
- Add test

### How can this be manually tested?

- `python manage.py test`
-  `/assets/`

#### What are the relevant pivotal tracker stories?

[ #157353629](https://www.pivotaltracker.com/n/projects/2146417/stories/157353629)

### Screenshots

View from the assets endpoint

<img width="1348" alt="screen shot 2018-06-06 at 13 32 10" src="https://user-images.githubusercontent.com/15943349/41033111-14c1412a-698e-11e8-9f70-ebee2f8d1c04.png">

View of the previous owners

<img width="580" alt="screen shot 2018-06-06 at 13 31 49" src="https://user-images.githubusercontent.com/15943349/41033121-1a5e1414-698e-11e8-9865-7a33ea07e935.png">

View of the previous owners 

<img width="500" alt="screen shot 2018-06-06 at 13 31 36" src="https://user-images.githubusercontent.com/15943349/41033127-1fd32786-698e-11e8-9480-49091b9098f6.png">
