### PR TITLE
#157966237 API default page

### DIFF
--- a/api/templates/api/api-index.html
+++ b/api/templates/api/api-index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Andela Resourse Tracker API</title>
+    <style>
+        .api-title {
+            height: 100%;
+            margin-top: 40vh;
+            margin-bottom: auto;
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+    <div class="api-title">
+        <h1>Andela Resource Tracker API {% if api_version %} ({{ api_version }}) {% endif %}</h1>
+    </div>
+</body>
+</html>

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,3 +1,4 @@
+from django.views.generic import TemplateView
 from rest_framework.routers import SimpleRouter
 from django.conf.urls import include
 from django.urls import path
@@ -54,7 +55,12 @@ urlpatterns = [
     path('docs/', schema_view.with_ui(
         'redoc', cache_timeout=None), name='schema-redoc'),
     path('docs/live/', schema_view.with_ui(
-        'swagger', cache_timeout=None), name='schema-swagger')
+        'swagger', cache_timeout=None), name='schema-swagger'),
+    path('', TemplateView.as_view(
+        template_name='api/api-index.html',
+        extra_context={'api_version': 'V1'}),
+        name='api-version-index'
+    )
 ]
 
 urlpatterns += router.urls

--- a/art/urls.py
+++ b/art/urls.py
@@ -18,6 +18,7 @@ from django.conf import settings
 from django.conf.urls import include
 from django.conf.urls.static import static
 from django.urls import path
+from django.views.generic import TemplateView
 
 from api import urls
 
@@ -26,6 +27,10 @@ urlpatterns = [
     path('api/v1/', include(urls)),
     path('jet/', include('jet.urls', 'jet')),
     path('jet/dashboard/', include('jet.dashboard.urls', 'jet-dashboard')),
+    path('', TemplateView.as_view(
+        template_name='api/api-index.html'),
+        name='api-home'
+    )
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
## What does this PR do?
Create a default page to be shown when the API index is viewed

## Description of task to be completed:
- create default page template
- map template to URLs using TemplateView

## How can this be manually tested?
- run `python manage.py runserver`
- navigate to [http://127.0.0.1:8000/](http://127.0.0.1:8000/) or [http://127.0.0.1:8000/api/v1](http://127.0.0.1:8000/api/v1) in browser

## What are the relevant pivotal tracker stories?
[#157966237](https://www.pivotaltracker.com/story/show/157966237)

## Screenshots
<img width="1387" alt="screen shot 2018-06-07 at 11 58 21 am" src="https://user-images.githubusercontent.com/31279497/41095918-ec5bf38e-6a4a-11e8-8682-0d3a90816ac2.png">

