### PR TITLE
#158686816 Make trailing slash optional

### DIFF
--- a/api/tests/test_allocation_api.py
+++ b/api/tests/test_allocation_api.py
@@ -104,7 +104,7 @@ class AllocationTestCase(APIBaseTestCase):
         )
         self.assertEqual(response.status_code, 201)
         response = client.get(
-            f"{reverse('assets-list')}{self.asset.serial_number}/",
+            f"{reverse('assets-list')}/{self.asset.serial_number}/",
             HTTP_AUTHORIZATION=token)
         self.assertEquals(response.data['current_status'], 'Allocated')
         self.assertEquals(

--- a/api/tests/test_asset_api.py
+++ b/api/tests/test_asset_api.py
@@ -94,7 +94,7 @@ class AssetTestCase(APIBaseTestCase):
     def test_authenticated_user_get_single_asset(self, mock_verify_id_token):
         mock_verify_id_token.return_value = {'email': self.other_user.email}
         response = client.get(
-            "{}{}/".format(self.asset_urls, self.asset.serial_number),
+            "{}/{}/".format(self.asset_urls, self.asset.serial_number),
             HTTP_AUTHORIZATION="Token {}".format(self.token_user))
         self.assertIn(self.asset.asset_code, response.data.values())
         self.assertEqual(response.status_code, 200)
@@ -155,7 +155,7 @@ class AssetTestCase(APIBaseTestCase):
     def test_assets_api_endpoint_cant_allow_put(self, mock_verify_id_token):
         mock_verify_id_token.return_value = {'email': self.user.email}
         response = client.put(
-            '{}{}/'.format(self.asset_urls, self.asset.serial_number),
+            '{}/{}/'.format(self.asset_urls, self.asset.serial_number),
             HTTP_AUTHORIZATION="Token {}".format(self.token_user))
         self.assertEqual(response.data, {
             'detail': 'Method "PUT" not allowed.'
@@ -165,7 +165,7 @@ class AssetTestCase(APIBaseTestCase):
     def test_assets_api_endpoint_cant_allow_patch(self, mock_verify_id_token):
         mock_verify_id_token.return_value = {'email': self.user.email}
         response = client.patch(
-            '{}{}/'.format(self.asset_urls, self.asset.serial_number),
+            '{}/{}/'.format(self.asset_urls, self.asset.serial_number),
             HTTP_AUTHORIZATION="Token {}".format(self.token_user))
         self.assertEqual(response.data, {
             'detail': 'Method "PATCH" not allowed.'
@@ -175,7 +175,7 @@ class AssetTestCase(APIBaseTestCase):
     def test_assets_api_endpoint_cant_allow_delete(self, mock_verify_id_token):
         mock_verify_id_token.return_value = {'email': self.user.email}
         response = client.delete(
-            '{}{}/'.format(self.asset_urls, self.asset.serial_number),
+            '{}/{}/'.format(self.asset_urls, self.asset.serial_number),
             HTTP_AUTHORIZATION="Token {}".format(self.token_user))
         self.assertEqual(response.data, {
             'detail': 'Method "DELETE" not allowed.'
@@ -186,7 +186,7 @@ class AssetTestCase(APIBaseTestCase):
             self, mock_verify_id_token):
         mock_verify_id_token.return_value = {'email': self.user.email}
         response = client.get(
-            '{}{}/'.format(self.asset_urls, self.asset.serial_number),
+            '{}/{}/'.format(self.asset_urls, self.asset.serial_number),
             HTTP_AUTHORIZATION="Token {}".format(self.token_user))
         self.assertIn(self.user.email,
                       response.data['assigned_to'].values())
@@ -197,7 +197,7 @@ class AssetTestCase(APIBaseTestCase):
             self, mock_verify_id_token):
         mock_verify_id_token.return_value = {'email': self.user.email}
         response = client.get(
-            '{}{}/'.format(self.asset_urls, self.asset.serial_number),
+            '{}/{}/'.format(self.asset_urls, self.asset.serial_number),
             HTTP_AUTHORIZATION="Token {}".format(self.token_user))
         self.assertNotIn('password', response.data['assigned_to'].keys())
         self.assertEqual(response.status_code, 200)
@@ -206,7 +206,7 @@ class AssetTestCase(APIBaseTestCase):
     def test_checkin_status_for_non_checked_asset(self, mock_verify_id_token):
         mock_verify_id_token.return_value = {'email': self.user.email}
         response = client.get(
-            '{}{}/'.format(self.asset_urls, self.asset.serial_number),
+            '{}/{}/'.format(self.asset_urls, self.asset.serial_number),
             HTTP_AUTHORIZATION="Token {}".format(self.token_user))
         self.assertIn('checkin_status', response.data.keys())
         self.assertEqual(response.data['checkin_status'], None)
@@ -223,7 +223,7 @@ class AssetTestCase(APIBaseTestCase):
 
         mock_verify_id_token.return_value = {'email': self.user.email}
         response = client.get(
-            '{}{}/'.format(self.asset_urls, self.asset.serial_number),
+            '{}/{}/'.format(self.asset_urls, self.asset.serial_number),
             HTTP_AUTHORIZATION="Token {}".format(self.token_user))
         self.assertIn('checkin_status', response.data.keys())
         self.assertEqual(response.data['checkin_status'],
@@ -240,7 +240,7 @@ class AssetTestCase(APIBaseTestCase):
         )
         mock_verify_id_token.return_value = {'email': self.user.email}
         response = client.get(
-            '{}{}/'.format(self.asset_urls, self.asset.serial_number),
+            '{}/{}/'.format(self.asset_urls, self.asset.serial_number),
             HTTP_AUTHORIZATION="Token {}".format(self.token_user))
         self.assertIn('checkin_status', response.data.keys())
         self.assertEqual(response.data['checkin_status'],
@@ -251,7 +251,7 @@ class AssetTestCase(APIBaseTestCase):
     def test_asset_type_in_asset_api(self, mock_verify_id_token):
         mock_verify_id_token.return_value = {'email': self.user.email}
         response = client.get(
-            '{}{}/'.format(self.asset_urls, self.asset.serial_number),
+            '{}/{}/'.format(self.asset_urls, self.asset.serial_number),
             HTTP_AUTHORIZATION="Token {}".format(self.token_user))
         self.assertIn('asset_type', response.data.keys())
         self.assertEqual(response.data['asset_type'],
@@ -292,7 +292,7 @@ class AssetTestCase(APIBaseTestCase):
             self, mock_verify_id_token):
         mock_verify_id_token.return_value = {'email': self.user.email}
         response = client.get(
-            '{}{}/'.format(self.asset_urls, self.asset.serial_number),
+            '{}/{}/'.format(self.asset_urls, self.asset.serial_number),
             HTTP_AUTHORIZATION="Token {}".format(self.token_user))
         self.assertIn('allocation_history', response.data.keys())
         self.assertEqual(response.status_code, 200)

--- a/api/tests/test_asset_category_api.py
+++ b/api/tests/test_asset_category_api.py
@@ -54,7 +54,7 @@ class AssetCategoryAPITest(APIBaseTestCase):
     def test_can_get_single_category(self, mock_verify_token):
         mock_verify_token.return_value = {'email': self.user.email}
         response = client.get(
-            f"{self.category_url}{self.asset_category.id}/",
+            f"{self.category_url}/{self.asset_category.id}/",
             HTTP_AUTHORIZATION="Token {}".format(self.token_user))
 
         self.assertIn("category_name", response.data.keys())

--- a/api/tests/test_asset_condition_api.py
+++ b/api/tests/test_asset_condition_api.py
@@ -129,8 +129,8 @@ class AssetConditionAPITest(APIBaseTestCase):
             HTTP_AUTHORIZATION='Token {}'.format(self.token_user))
         self.assertEqual(new_asset_condition.status_code, 201)
         response = client.get(
-            '{}{}/'.format(self.asset_condition_urls,
-                           new_asset_condition.data['id']),
+            '{}/{}/'.format(self.asset_condition_urls,
+                            new_asset_condition.data['id']),
             HTTP_AUTHORIZATION='Token {}'.format(self.token_user))
         self.assertEqual(response.data['id'], new_asset_condition.data['id'])
         self.assertEqual(response.status_code, 200)

--- a/api/tests/test_asset_health_api.py
+++ b/api/tests/test_asset_health_api.py
@@ -123,7 +123,7 @@ class AssetHealthTestCase(APIBaseTestCase):
                                                        mock_verify_id_token):
         mock_verify_id_token.return_value = {'email': self.user.email}
         response = client.delete(
-            '{}{}/'.format(self.asset_urls, self.asset.serial_number),
+            '{}/{}/'.format(self.asset_urls, self.asset.serial_number),
             HTTP_AUTHORIZATION="Token {}".format(self.token_user))
         self.assertEqual(response.data, {
             'detail': 'Method "DELETE" not allowed.'

--- a/api/tests/test_asset_incident_report_api.py
+++ b/api/tests/test_asset_incident_report_api.py
@@ -127,7 +127,7 @@ class AssetIncidentReportAPITest(APIBaseTestCase):
             self, mock_verify_id_token):
         mock_verify_id_token.return_value = {'email': self.user.email}
         response = client.get(
-            f"{self.incident_report_url}{self.incident_report.id}/",
+            f"{self.incident_report_url}/{self.incident_report.id}/",
             HTTP_AUTHORIZATION="Token {}".format(self.token_user))
         self.assertIn(self.incident_report.id, response.data.values())
         self.assertEqual(response.status_code, 200)

--- a/api/tests/test_asset_log.py
+++ b/api/tests/test_asset_log.py
@@ -225,7 +225,7 @@ class AssetLogModelTest(APIBaseTestCase):
             self, mock_verify_id_token):
         mock_verify_id_token.return_value = {'email': self.checked_by.email}
         response = client.get(
-            "{}{}/".format(self.asset_logs_url, self.checkin.id),
+            "{}/{}/".format(self.asset_logs_url, self.checkin.id),
             HTTP_AUTHORIZATION="Token {}".format(self.token_checked_by))
         self.assertEqual(response.data['id'], self.checkin.id)
         self.assertEqual(response.status_code, 200)
@@ -235,7 +235,7 @@ class AssetLogModelTest(APIBaseTestCase):
             self, mock_verify_id_token):
         mock_verify_id_token.return_value = {'email': self.checked_by.email}
         response = client.delete(
-            "{}{}/".format(self.asset_logs_url, self.checkin.id),
+            "{}/{}/".format(self.asset_logs_url, self.checkin.id),
             HTTP_AUTHORIZATION="Token {}".format(self.token_checked_by))
         self.assertEqual(response.data, {
             'detail': 'Method "DELETE" not allowed.'
@@ -247,7 +247,7 @@ class AssetLogModelTest(APIBaseTestCase):
             self, mock_verify_id_token):
         mock_verify_id_token.return_value = {'email': self.checked_by.email}
         response = client.put(
-            "{}{}/".format(self.asset_logs_url, self.checkin.id),
+            "{}/{}/".format(self.asset_logs_url, self.checkin.id),
             HTTP_AUTHORIZATION="Token {}".format(self.token_checked_by))
         self.assertEqual(response.data, {
             'detail': 'Method "PUT" not allowed.'
@@ -259,7 +259,7 @@ class AssetLogModelTest(APIBaseTestCase):
             self, mock_verify_id_token):
         mock_verify_id_token.return_value = {'email': self.checked_by.email}
         response = client.patch(
-            "{}{}/".format(self.asset_logs_url, self.checkin.id),
+            "{}/{}/".format(self.asset_logs_url, self.checkin.id),
             HTTP_AUTHORIZATION="Token {}".format(self.token_checked_by))
         self.assertEqual(response.data, {
             'detail': 'Method "PATCH" not allowed.'

--- a/api/tests/test_asset_make_api.py
+++ b/api/tests/test_asset_make_api.py
@@ -134,7 +134,7 @@ class AssetMakeAPICase(APIBaseTestCase):
     def test_assets_api_endpoint_cant_allow_put(self, mock_verify_id_token):
         mock_verify_id_token.return_value = {'email': self.user.email}
         response = client.put(
-            '{}{}/'.format(self.asset_make_urls, self.asset_make.id),
+            '{}/{}/'.format(self.asset_make_urls, self.asset_make.id),
             HTTP_AUTHORIZATION='Token {}'.format(self.token_user))
         self.assertEqual(response.data, {
             'detail': 'Method "PUT" not allowed.'
@@ -145,7 +145,7 @@ class AssetMakeAPICase(APIBaseTestCase):
     def test_can_get_single_asset_make(self, mock_verify_token):
         mock_verify_token.return_value = {'email': self.user.email}
         response = client.get(
-            f'{self.asset_make_urls}{self.asset_make.id}/',
+            f'{self.asset_make_urls}/{self.asset_make.id}/',
             HTTP_AUTHORIZATION='Token {}'.format(self.token_user))
 
         self.assertIn('make_label', response.data.keys())

--- a/api/tests/test_asset_model_number_api.py
+++ b/api/tests/test_asset_model_number_api.py
@@ -80,7 +80,7 @@ class AssetModelNumberAPITest(APIBaseTestCase):
     def test_can_get_single_asset_model_number(self, mock_verify_token):
         mock_verify_token.return_value = {'email': self.user.email}
         response = client.get(
-            f'{self.asset_model_no_url}{self.asset_model_no.id}/',
+            f'{self.asset_model_no_url}/{self.asset_model_no.id}/',
             HTTP_AUTHORIZATION='Token {}'.format(self.token_user))
 
         self.assertIn('model_number', response.data.keys())

--- a/api/tests/test_asset_status_api.py
+++ b/api/tests/test_asset_status_api.py
@@ -58,7 +58,7 @@ class AssetStatusAPITest(APIBaseTestCase):
             self, mock_verify_id_token):
         mock_verify_id_token.return_value = {'email': self.normal_user.email}
         response = client.get(
-            '{}{}/'.format(self.asset_status_urls, self.asset_status.id),
+            '{}/{}/'.format(self.asset_status_urls, self.asset_status.id),
             HTTP_AUTHORIZATION="Token {}".format(self.token_user))
         self.assertIn(self.asset_status.asset_id, response.data.values())
         self.assertEqual(response.status_code, 200)

--- a/api/tests/test_asset_sub_category_api.py
+++ b/api/tests/test_asset_sub_category_api.py
@@ -65,7 +65,7 @@ class AssetCategoryAPITest(APIBaseTestCase):
     def test_can_get_single_sub_category(self, mock_verify_token):
         mock_verify_token.return_value = {'email': self.user.email}
         response = client.get(
-            f"{self.asset_sub_category_url}{self.asset_sub_category.id}/",
+            f"{self.asset_sub_category_url}/{self.asset_sub_category.id}/",
             HTTP_AUTHORIZATION="Token {}".format(self.token_user))
 
         self.assertIn("sub_category_name", response.data.keys())

--- a/api/tests/test_asset_type_api.py
+++ b/api/tests/test_asset_type_api.py
@@ -70,7 +70,7 @@ class AssetCategoryAPITest(APIBaseTestCase):
     def test_can_get_single_asset_type(self, mock_verify_token):
         mock_verify_token.return_value = {'email': self.user.email}
         response = client.get(
-            f"{self.asset_type_url}{self.asset_type.id}/",
+            f"{self.asset_type_url}/{self.asset_type.id}/",
             HTTP_AUTHORIZATION="Token {}".format(self.token_user))
 
         self.assertIn("asset_type", response.data.keys())

--- a/api/urls.py
+++ b/api/urls.py
@@ -24,7 +24,14 @@ schema_view = get_schema_view(
     public=True,
 )
 
-router = SimpleRouter()
+
+class OptionalSlashRouter(SimpleRouter):
+    def __init__(self, trailing_slash='/?'):
+        self.trailing_slash = trailing_slash
+        super(SimpleRouter, self).__init__()
+
+
+router = OptionalSlashRouter()
 router.register('users', UserViewSet)
 router.register('assets', AssetViewSet, 'assets')
 router.register('allocations', AllocationsViewSet, 'allocations')


### PR DESCRIPTION
## What does this PR do?
- It makes adding trailing slash optional in a request URL

## Description of Task to be completed
- subclasses `SimpleRouter` to add option trailing comma functionality

## Relevant Pivotal Tracker stories
[#158686816](https://www.pivotaltracker.com/story/show/158686816)

## Screenshots
<img width="1195" alt="screen shot 2018-06-28 at 1 21 26 pm" src="https://user-images.githubusercontent.com/31279497/42034180-2223dfa8-7ad7-11e8-98e8-be5e5e33141b.png">
<img width="1213" alt="screen shot 2018-06-28 at 1 20 59 pm" src="https://user-images.githubusercontent.com/31279497/42034181-225b19be-7ad7-11e8-9537-fb576a649e51.png">
