### PR TITLE
#158946377: Whitelist CORS origin for staging domain name 

### DIFF
--- a/settings/dev.py
+++ b/settings/dev.py
@@ -10,7 +10,17 @@ MIDDLEWARE += [  # noqa ignore=F405
     'debug_toolbar.middleware.DebugToolbarMiddleware',
 ]
 
-ALLOWED_HOSTS = [os.environ.get('MY_HOST_IP'), 'api-staging-art.andela.com']
+
+ALLOWED_HOSTS = [os.environ.get('MY_HOST_IP'), 'api-staging-art.andela.com',
+                 '127.0.0.1']
+
+CORS_ORIGIN_WHITELIST = (
+    'art-dashboard-staging.herokuapp.com'
+)
+
+CORS_ORIGIN_REGEX_WHITELIST = (
+    r'^(https?:\/\/)?(.+\.)?(andela\.com)|((localhost)|(127\.0\.0\.1):\d{4})',
+)
 
 INTERNAL_IPS = [
     '0.0.0.0',

--- a/settings/prod.py
+++ b/settings/prod.py
@@ -2,12 +2,7 @@ from .base import *  # noqa: F403,F401
 import os
 DEBUG = False
 
-ALLOWED_HOSTS = [os.environ.get('MY_HOST_IP'), 'api-staging-art.andela.com',
-                 'art-backend.herokuapp.com']
-
-CORS_ORIGIN_WHITELIST = (
-    'art-dashboard-staging.herokuapp.com'
-)
+ALLOWED_HOSTS = [os.environ.get('MY_HOST_IP')]
 
 CORS_ORIGIN_REGEX_WHITELIST = \
-    (r'^(https?:\/\/)?(\w+\.)?((localhost)|(127\.0\.0\.1)):\d{4}', )
+    (r'^(https?:\/\/)?(.+\.)?((andela\.com))', )


### PR DESCRIPTION
**What does this PR do?**

- Adds the frontend  staging host name to  CORS_ORIGIN_WHITELIST to enable cross-site requests

**Description of Task to be completed?**

- Whitelist frontend staging domain name 

- Create  cors origin  regex 

**Relevant Pivotal Tracker stories**

[#158946377](https://www.pivotaltracker.com/story/show/158946377)