### PR TITLE
#159023098 Modify asset specs addition

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -100,6 +100,18 @@ class AssetSerializer(serializers.ModelSerializer):
             for allocation in allocations
         ]
 
+    def to_internal_value(self, data):
+        internals = super().to_internal_value(data)
+        specs_serializer = AssetSpecsSerializer(data=data)
+        specs_serializer.is_valid()
+
+        if len(specs_serializer.data):
+            specs, _ = AssetSpecs.objects.get_or_create(
+                **specs_serializer.data
+            )
+            internals['specs'] = specs
+        return internals
+
 
 class SecurityUserEmailsSerializer(serializers.ModelSerializer):
     class Meta:

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from django.core.exceptions import ValidationError
 from core.models import (
     User, Asset, SecurityUser, AssetLog,
     UserFeedback, CHECKIN, CHECKOUT, AssetStatus, AllocationHistory,
@@ -101,14 +102,17 @@ class AssetSerializer(serializers.ModelSerializer):
         ]
 
     def to_internal_value(self, data):
-        internals = super().to_internal_value(data)
+        internals = super(AssetSerializer, self).to_internal_value(data)
         specs_serializer = AssetSpecsSerializer(data=data)
         specs_serializer.is_valid()
 
         if len(specs_serializer.data):
-            specs, _ = AssetSpecs.objects.get_or_create(
-                **specs_serializer.data
-            )
+            try:
+                specs, _ = AssetSpecs.objects.get_or_create(
+                    **specs_serializer.data
+                )
+            except ValidationError as err:
+                raise serializers.ValidationError(err.error_dict)
             internals['specs'] = specs
         return internals
 

--- a/api/tests/test_manage_asset_api.py
+++ b/api/tests/test_manage_asset_api.py
@@ -134,7 +134,10 @@ class ManageAssetTestCase(APIBaseTestCase):
             "asset_code": "IC002",
             "serial_number": "SN002",
             "model_number": self.assetmodel.model_number,
-            "purchase_date": "2018-07-10"
+            "purchase_date": "2018-07-10",
+            "processor_type": "Intel core i3",
+            "processor_speed": 2.3,
+            "screen_size": 15
         }
         response = client.post(
             self.manage_asset_urls,
@@ -147,6 +150,10 @@ class ManageAssetTestCase(APIBaseTestCase):
             data.get("serial_number"), res_data.get("serial_number"))
         self.assertEqual(
             data.get("model_number"), res_data.get("model_number"))
+        self.assertIsNotNone(res_data.get('specs', None))
+        self.assertEqual(
+            data['screen_size'],
+            res_data.get('specs').get('screen_size'))
         self.assertEqual(Asset.objects.count(), 2)
         self.assertEqual(response.status_code, 201)
 

--- a/api/tests/test_manage_asset_api.py
+++ b/api/tests/test_manage_asset_api.py
@@ -199,6 +199,25 @@ class ManageAssetTestCase(APIBaseTestCase):
         self.assertIn("processor_speed", response.data)
 
     @patch('api.authentication.auth.verify_id_token')
+    def test_admin_cannot_post_asset_with_missing_fields(
+            self,
+            mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.admin.email}
+        data = {
+            "model_number": self.assetmodel.model_number,
+            "purchase_date": "2018-07-10"
+        }
+
+        response = client.post(
+            self.manage_asset_urls,
+            data=data,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data['__all__'][0],
+            "['Please provide either the serial number, asset code or both.']")
+
+    @patch('api.authentication.auth.verify_id_token')
     def test_cannot_post_asset_with_invalid_model_number(
             self, mock_verify_id_token):
         mock_verify_id_token.return_value = {'email': self.admin.email}

--- a/api/views.py
+++ b/api/views.py
@@ -60,6 +60,13 @@ class ManageAssetViewSet(ModelViewSet):
         obj = get_object_or_404(queryset, serial_number=self.kwargs['pk'])
         return obj
 
+    def create(self, request, *args, **kwargs):
+        try:
+            response = super().create(request, *args, **kwargs)
+        except ValidationError as err:
+            raise serializers.ValidationError(err.error_dict)
+        return response
+
 
 class AssetViewSet(ModelViewSet):
     serializer_class = AssetSerializer


### PR DESCRIPTION
## What does this PR do?
- Implement creating asset specs via asset endpoint

## Description of the tasks to be completed
- modify `AssetSerializer`'s `to_internal_values` serializer method to include asset specs
- test for specs creation via asset endpoint

## Relevant Pivotal Tracker stories
[#159023098](https://www.pivotaltracker.com/story/show/159023098)

## Screenshot
<img width="1222" alt="screen shot 2018-07-23 at 10 25 05 pm" src="https://user-images.githubusercontent.com/31279497/43105393-a14d73da-8ecc-11e8-9320-3cd74c3d2274.png">
<img width="981" alt="screen shot 2018-07-23 at 10 25 32 pm" src="https://user-images.githubusercontent.com/31279497/43105394-a179cd18-8ecc-11e8-9d63-70840ea8b5ff.png">
