### PR TITLE
[#160192826]: Admin can filter assets by asset status

### DIFF
--- a/api/filters.py
+++ b/api/filters.py
@@ -15,6 +15,10 @@ class AssetFilter(filters.FilterSet):
         field_name='model_number__make_label__asset_type__asset_type',
         lookup_expr='iexact',
         method='filter_with_multiple_query_values')
+    current_status = filters.CharFilter(
+        field_name='current_status',
+        lookup_expr='iexact',
+    )
 
     def filter_with_multiple_query_values(self, queryset, name, value):
         lookup = '__'.join([name, 'in'])
@@ -22,7 +26,7 @@ class AssetFilter(filters.FilterSet):
 
     class Meta:
         model = Asset
-        fields = ['asset_type', 'model_number', 'email']
+        fields = ['asset_type', 'model_number', 'email', 'current_status']
 
 
 class UserFilter(filters.FilterSet):

--- a/api/tests/test_asset_api.py
+++ b/api/tests/test_asset_api.py
@@ -34,6 +34,11 @@ class AssetTestCase(APIBaseTestCase):
         self.another_asset_assignee = \
             AssetAssignee.objects.get(user=self.other_user)
         self.token_other_user = 'otherusertesttoken'
+        self.admin_user = User.objects.create_superuser(
+            email='admin@site.com', cohort=20,
+            slack_handle='@admin', password='devpassword'
+        )
+        self.token_admin = 'admintesttoken'
         self.asset_category = AssetCategory.objects.create(
             category_name="Accessories")
         self.asset_sub_category = AssetSubCategory.objects.create(
@@ -135,9 +140,47 @@ class AssetTestCase(APIBaseTestCase):
         response = client.get(
             '{}?email={}'.format(self.asset_urls, self.user.email),
             HTTP_AUTHORIZATION="Token {}".format(self.token_user))
-        self.assertTrue(len(response.data) > 0)
         self.assertIn(self.user.email,
                       response.data['results'][0]['assigned_to']['email'])
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_non_admin_cannot_filter_asset_by_asset_status(self, mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.user.email}
+        url = reverse('manage-assets-list')
+        response = client.get(
+            '{}?current_status={}'.format(url, 'Allocated'),
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user))
+        self.assertEqual(response.data, {
+            'detail': 'You do not have permission to perform this action.'
+        })
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_admin_can_filter_asset_by_asset_status(self, mock_verify_id_token):
+        mock_verify_id_token.return_value = {'email': self.admin_user.email}
+        url = reverse('manage-assets-list')
+        response = client.get(
+            '{}?current_status={}'.format(url, 'Allocated'),
+            HTTP_AUTHORIZATION="Token {}".format(self.token_admin))
+
+        self.assertEqual(response.data['count'], 1)
+
+        response = client.get(
+            '{}?current_status={}'.format(url, 'Available'),
+            HTTP_AUTHORIZATION="Token {}".format(self.token_admin))
+        self.assertEqual(response.data['count'], 0)
+
+        new_asset = Asset(
+            asset_code="IC002",
+            serial_number="SN002",
+            model_number=self.assetmodel,
+            purchase_date="2018-07-10"
+        )
+        new_asset.save()
+
+        response = client.get(
+            '{}?current_status={}'.format(url, 'Available'),
+            HTTP_AUTHORIZATION="Token {}".format(self.token_admin))
+        self.assertEqual(response.data['count'], 1)
 
     @patch('api.authentication.auth.verify_id_token')
     def test_assets_detail_api_endpoint_contain_assigned_to_details(


### PR DESCRIPTION
### What does this PR do?

 •Allows an admin to filter assets using the asset status

### Description of task to be completed:

  •Add current_status to the FilterSet
  •Add tests

### How can this be manually tested?

•Provide the query `current_status` to the manage-assets endpoint as an admin 

### Relevant pivotal tracker stories

  •[#160192826](https://www.pivotaltracker.com/story/show/160192826)

### Screenshots
![screen shot 2018-09-05 at 06 38 49](https://user-images.githubusercontent.com/13068580/45069687-752a5a80-b0d6-11e8-9249-a17d10613a08.png)
![screen shot 2018-09-05 at 06 39 05](https://user-images.githubusercontent.com/13068580/45069691-79567800-b0d6-11e8-9394-bb857e45181f.png)
