### PR TITLE
[#160312740] Sets default ordering for the following models

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -11,6 +11,7 @@ from rest_framework import status
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
 from rest_framework.viewsets import ModelViewSet
 from django_filters import rest_framework as filters
+from rest_framework.filters import OrderingFilter
 from api.authentication import FirebaseTokenAuthentication
 from api.filters import AssetFilter, UserFilter
 from core.models import Asset, SecurityUser, AssetLog, UserFeedback, \
@@ -154,6 +155,8 @@ class AssetCategoryViewSet(ModelViewSet):
     queryset = AssetCategory.objects.all()
     permission_classes = [IsAuthenticated, ]
     authentication_classes = (FirebaseTokenAuthentication,)
+    filter_backends = (OrderingFilter,)
+    ordering = ('category_name',)
     http_method_names = ['get', 'post']
 
 
@@ -162,6 +165,8 @@ class AssetSubCategoryViewSet(ModelViewSet):
     queryset = AssetSubCategory.objects.all()
     permission_classes = [IsAuthenticated, ]
     authentication_classes = (FirebaseTokenAuthentication,)
+    filter_backends = (OrderingFilter,)
+    ordering = ('sub_category_name',)
     http_method_names = ['get', 'post']
 
 
@@ -170,6 +175,8 @@ class AssetTypeViewSet(ModelViewSet):
     queryset = AssetType.objects.all()
     permission_classes = [IsAuthenticated, ]
     authentication_classes = (FirebaseTokenAuthentication,)
+    filter_backends = (OrderingFilter,)
+    ordering = ('asset_type',)
     http_method_names = ['get', 'post']
 
 
@@ -178,6 +185,8 @@ class AssetModelNumberViewSet(ModelViewSet):
     queryset = AssetModelNumber.objects.all()
     permission_classes = [IsAuthenticated, ]
     authentication_classes = [FirebaseTokenAuthentication, ]
+    filter_backends = (OrderingFilter,)
+    ordering = ('model_number',)
     http_method_names = ['get', 'post']
 
 
@@ -186,6 +195,8 @@ class AssetMakeViewSet(ModelViewSet):
     queryset = AssetMake.objects.all()
     permission_classes = [IsAuthenticated, ]
     authentication_classes = [FirebaseTokenAuthentication, ]
+    filter_backends = (OrderingFilter,)
+    ordering = ('make_label',)
     http_method_names = ['get', 'post']
 
 


### PR DESCRIPTION
### What does PR do?

  •Sets default ordering for 

- 	Asset Categories model
-	Asset Subcategories model
-	Asset Models model
-	Asset Makes model
-	Asset types model

### Description of task to be completed:

  •Set default ordering for the above models

### How can this be manually tested?

  •As an admin, navigate to the respective endpoints

### Relevant pivotal tracker stories
[#160312740](https://www.pivotaltracker.com/story/show/#160312740)  

### Screenshots
![screen shot 2018-09-14 at 10 22 27](https://user-images.githubusercontent.com/13068580/45536714-f71f2f80-b80a-11e8-83b7-6f522a47d17f.png)
![screen shot 2018-09-14 at 10 23 37](https://user-images.githubusercontent.com/13068580/45536726-fdada700-b80a-11e8-9070-7a6d409c2b93.png)
![screen shot 2018-09-14 at 10 24 59](https://user-images.githubusercontent.com/13068580/45536760-16b65800-b80b-11e8-9d53-6fbfd99d49cd.png)
![screen shot 2018-09-14 at 10 25 55](https://user-images.githubusercontent.com/13068580/45536776-1a49df00-b80b-11e8-9f2c-849feb7df4bf.png)
![screen shot 2018-09-14 at 10 26 04](https://user-images.githubusercontent.com/13068580/45536809-3188cc80-b80b-11e8-8299-1be6d98f9810.png)
![screen shot 2018-09-14 at 10 21 36](https://user-images.githubusercontent.com/13068580/45536820-38174400-b80b-11e8-9f8d-938aa2f5a8b5.png)

