### PR TITLE
[#160194424] Restrict docs to staging

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -80,9 +80,9 @@ urlpatterns = [
     path('upload/', AssetsImportViewSet.as_view(), name='import-assets')
 ]
 if os.getenv('APP_ENV'):
-    urlpatterns.extend(
-        [path('docs/', schema_view.with_ui(
-            'redoc', cache_timeout=None), name='schema-redoc'), path('docs/live/', schema_view.with_ui(
-                'swagger', cache_timeout=None), name='schema-swagger')])
+    urlpatterns.extend([
+        path('docs/', schema_view.with_ui('redoc', cache_timeout=None), name='schema-redoc'),
+        path('docs/live/', schema_view.with_ui('swagger', cache_timeout=None), name='schema-swagger')
+    ])
 
 urlpatterns += router.urls

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,3 +1,4 @@
+import os
 from django.views.generic import TemplateView
 from rest_framework.routers import SimpleRouter
 from django.conf.urls import include
@@ -71,10 +72,6 @@ router.register('asset-assignee', AssetAssigneeViewSet, 'asset-assignee')
 urlpatterns = [
     path('api-auth/', include('rest_framework.urls')),
     path('o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
-    path('docs/', schema_view.with_ui(
-        'redoc', cache_timeout=None), name='schema-redoc'),
-    path('docs/live/', schema_view.with_ui(
-        'swagger', cache_timeout=None), name='schema-swagger'),
     path('', TemplateView.as_view(
         template_name='api/api-index.html',
         extra_context={'api_version': 'V1'}),
@@ -82,5 +79,10 @@ urlpatterns = [
     ),
     path('upload/', AssetsImportViewSet.as_view(), name='import-assets')
 ]
+if os.getenv('APP_ENV'):
+    urlpatterns.extend(
+        [path('docs/', schema_view.with_ui(
+            'redoc', cache_timeout=None), name='schema-redoc'), path('docs/live/', schema_view.with_ui(
+                'swagger', cache_timeout=None), name='schema-swagger')])
 
 urlpatterns += router.urls


### PR DESCRIPTION
### What does PR do?

- Restricts api docs to staging

### Description of the task to be completed:
  Ensure that `docs/` and `docs/live/` can only be accessed on staging.
 ### How can this be manually tested?
Setting the `APP_ENV` to `dev` then you should be able to access the docs. Otherwise, you can't be able to access them.
### Relevant pivotal tracker stories
[#160194424](https://www.pivotaltracker.com/story/show/160194424)  
