### PR TITLE
feat[#161049350]: An admin can edit and delete a security user

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -323,7 +323,17 @@ class SecurityUserViewSet(ModelViewSet):
     queryset = SecurityUser.objects.all()
     permission_classes = [IsAuthenticated, IsAdminUser]
     authentication_classes = [FirebaseTokenAuthentication, ]
-    http_method_names = ['get', 'post']
+    http_method_names = ['get', 'post', 'put', 'delete']
+
+    def destroy(self, request, *args, **kwargs):
+        instance = self.get_object()
+        self.perform_destroy(instance)
+        data = {"detail": "Deleted Successfully"}
+        return Response(data=data, status=status.HTTP_204_NO_CONTENT)
+
+    def update(self, request, *args, **kwargs):
+        kwargs['partial'] = True
+        return super(SecurityUserViewSet, self).update(request, *args, **kwargs)
 
 
 class AssetSpecsViewSet(ModelViewSet):


### PR DESCRIPTION
### What does this PR do?

- Allows an Admin user edit and delete a security user.

### Description of task to be completed:

- Add **put** and **delete** http verb to the existing _security-user_ endpoint.

### How can this be manually tested?

- navigate to the **/api/v1/security-users** endpoint and try the edit and delete functionality.