### PR TITLE
[#162050415] Allows only a superuser to edit an asset location

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -11,6 +11,7 @@ from django.contrib.auth.models import Group
 from django.core.validators import ValidationError
 from django.http import FileResponse
 from rest_framework import serializers
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.generics import get_object_or_404
 from rest_framework.parsers import MultiPartParser
 from rest_framework.response import Response
@@ -84,6 +85,14 @@ class ManageAssetViewSet(ModelViewSet):
 
     def perform_create(self, serializer):
         serializer.save(asset_location=self.request.user.location)
+
+    def perform_update(self, serializer):
+        if serializer.validated_data.get('asset_location'):
+            # check if it is a super user performing this
+            if not self.request.user.is_superuser:
+                raise PermissionDenied(
+                    "Only a super user can update an asset location")
+        serializer.save()
 
 
 class AssetViewSet(ModelViewSet):


### PR DESCRIPTION
### What does this PR do?

    •Enables syncing of users on AIS to ART

### Description of task to be completed:

    •Allows only a superuser to edit an asset location

### How can this be manually tested?

    • Login as a normal user and try to update an asset location

### Relevant pivotal tracker stories:

[#162050415](https://www.pivotaltracker.com/story/show/162050415)