### PR TITLE
Fixes a false skipped assets on upload-assets endpoint

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -46,6 +46,8 @@ from .serializers import UserSerializerWithAssets, \
     OfficeFloorSectionSerializer, OfficeFloorSerializer, UserGroupSerializer, \
     OfficeWorkspaceSerializer, DepartmentSerializer, \
     AssetAssigneeSerializer, AndelaCentreSerializer
+
+from core.management.commands.import_assets import SKIPPED_ROWS
 from api.permissions import IsApiUser, IsSecurityUser
 
 User = get_user_model()
@@ -459,6 +461,7 @@ class AssetsImportViewSet(APIView):
         response['success'] = "Asset import completed successfully "
         if error:
             response['success'] += "Assets that have not been imported have been written to a file."
+        del SKIPPED_ROWS[:]
         return Response(data=response, status=200)
 
 


### PR DESCRIPTION
### What does PR do?

	•Fixes a bug where after some assets fail to be saved, on uploading another file with no errors, fake skipped assets are reported.

### Description of task to be completed:

	•Clear the global list that holds all skipped assets while returning a response to the user.

### Related pivotal tracker stories

	[#162539794](https://www.pivotaltracker.com/story/show/162539794)
