### PR TITLE
Ft admin can change security user status

### DIFF
--- a/api/serializers/users.py
+++ b/api/serializers/users.py
@@ -105,6 +105,7 @@ class SecurityUserSerializer(serializers.ModelSerializer):
             'last_name',
             'email',
             'badge_number',
+            'is_active',
             'phone_number',
             'last_modified',
             'date_joined',


### PR DESCRIPTION
### What does this PR do?

- Allows admin to change security user status.

### Description of task to be completed.

- A verified Admin user should be able to change the status of a security user by changing the value of the _is_active_ field to either True or False.

### How can it be tested manually?

- As an admin user, Navigate to security user endpoint and change the status of a security user.

### Screenshots.
<img width="1280" alt="screen shot 2019-01-21 at 11 31 15 am" src="https://user-images.githubusercontent.com/26963854/51469364-7e5c5100-1d71-11e9-91fc-b384ede4242b.png">
