### PR TITLE
Bug: Fix repeating asset log-#164726859

### DIFF
--- a/api/serializers/assets.py
+++ b/api/serializers/assets.py
@@ -161,6 +161,13 @@ class AssetLogSerializer(serializers.ModelSerializer):
         instance_data["asset"] = f"{serial_no} - {asset_code}"
         return instance_data
 
+    def validate(self, fields):
+        if models.AssetLog.objects.filter(**fields).exists():
+            raise serializers.ValidationError(
+                'Log for this asset already exist'
+            )
+        return fields
+
 
 class AssetStatusSerializer(AssetSerializer):
     status_history = serializers.SerializerMethodField()

--- a/api/serializers/assets.py
+++ b/api/serializers/assets.py
@@ -163,9 +163,7 @@ class AssetLogSerializer(serializers.ModelSerializer):
 
     def validate(self, fields):
         if models.AssetLog.objects.filter(**fields).exists():
-            raise serializers.ValidationError(
-                'Log for this asset already exist'
-            )
+            raise serializers.ValidationError('Log for this asset already exist')
         return fields
 
 

--- a/api/tests/test_asset_log.py
+++ b/api/tests/test_asset_log.py
@@ -60,6 +60,23 @@ class AssetLogModelTest(APIBaseTestCase):
             log_type="Checkin",
         )
         self.assertEqual(AssetLog.objects.count(), 3)
+        created_log = AssetLog.objects.filter(asset=self.test_other_asset).first()
+        self.assertEqual(created_log.log_type, "Checkin")
+
+    def test_verify_double_checkin_for_asset(self):
+        # First log
+        AssetLog.objects.create(
+            checked_by=self.security_user,
+            asset=self.test_other_asset,
+            log_type="Checkin",
+        )
+        # Second log
+        AssetLog.objects.create(
+            checked_by=self.security_user,
+            asset=self.test_other_asset,
+            log_type="Checkin",
+        )
+        self.assertEqual(AssetLog.objects.count(), 3)
 
     def test_add_checkout(self):
         AssetLog.objects.create(
@@ -69,6 +86,21 @@ class AssetLogModelTest(APIBaseTestCase):
         )
         self.assertEqual(AssetLog.objects.count(), 3)
     
+    def test_verify_double_checkout_for_asset(self):
+        # First log
+        AssetLog.objects.create(
+            checked_by=self.security_user,
+            asset=self.test_other_asset,
+            log_type="Checkout",
+        )
+        # Second log
+        AssetLog.objects.create(
+            checked_by=self.security_user,
+            asset=self.test_other_asset,
+            log_type="Checkout",
+        )
+        self.assertEqual(AssetLog.objects.count(), 3)
+
     def test_verify_double_checkout_for_asset(self):
         # First log
         AssetLog.objects.create(

--- a/api/tests/test_asset_log.py
+++ b/api/tests/test_asset_log.py
@@ -60,40 +60,8 @@ class AssetLogModelTest(APIBaseTestCase):
             log_type="Checkin",
         )
         self.assertEqual(AssetLog.objects.count(), 3)
-        created_log = AssetLog.objects.filter(asset=self.test_other_asset).first()
-        self.assertEqual(created_log.log_type, "Checkin")
-
-    def test_verify_double_checkin_for_asset(self):
-        # First log
-        AssetLog.objects.create(
-            checked_by=self.security_user,
-            asset=self.test_other_asset,
-            log_type="Checkin",
-        )
-        # Second log
-        AssetLog.objects.create(
-            checked_by=self.security_user,
-            asset=self.test_other_asset,
-            log_type="Checkin",
-        )
-        self.assertEqual(AssetLog.objects.count(), 3)
 
     def test_add_checkout(self):
-        AssetLog.objects.create(
-            checked_by=self.security_user,
-            asset=self.test_other_asset,
-            log_type="Checkout",
-        )
-        self.assertEqual(AssetLog.objects.count(), 3)
-    
-    def test_verify_double_checkout_for_asset(self):
-        # First log
-        AssetLog.objects.create(
-            checked_by=self.security_user,
-            asset=self.test_other_asset,
-            log_type="Checkout",
-        )
-        # Second log
         AssetLog.objects.create(
             checked_by=self.security_user,
             asset=self.test_other_asset,

--- a/api/tests/test_asset_log.py
+++ b/api/tests/test_asset_log.py
@@ -43,8 +43,40 @@ class AssetLogModelTest(APIBaseTestCase):
             log_type="Checkin",
         )
         self.assertEqual(AssetLog.objects.count(), 3)
+        created_log = AssetLog.objects.filter(asset=self.test_other_asset).first()
+        self.assertEqual(created_log.log_type, "Checkin")
+
+    def test_verify_double_checkin_for_asset(self):
+        # First log
+        AssetLog.objects.create(
+            checked_by=self.security_user,
+            asset=self.test_other_asset,
+            log_type="Checkin",
+        )
+        # Second log
+        AssetLog.objects.create(
+            checked_by=self.security_user,
+            asset=self.test_other_asset,
+            log_type="Checkin",
+        )
+        self.assertEqual(AssetLog.objects.count(), 3)
 
     def test_add_checkout(self):
+        AssetLog.objects.create(
+            checked_by=self.security_user,
+            asset=self.test_other_asset,
+            log_type="Checkout",
+        )
+        self.assertEqual(AssetLog.objects.count(), 3)
+    
+    def test_verify_double_checkout_for_asset(self):
+        # First log
+        AssetLog.objects.create(
+            checked_by=self.security_user,
+            asset=self.test_other_asset,
+            log_type="Checkout",
+        )
+        # Second log
         AssetLog.objects.create(
             checked_by=self.security_user,
             asset=self.test_other_asset,

--- a/api/tests/test_asset_log.py
+++ b/api/tests/test_asset_log.py
@@ -8,8 +8,8 @@ from rest_framework.test import APIClient
 
 # App Imports
 from api.tests import APIBaseTestCase
-from core.models import Asset, AssetLog, AssetModelNumber
 from core.constants import CHECKIN, CHECKOUT
+from core.models import Asset, AssetLog, AssetModelNumber
 
 User = get_user_model()
 client = APIClient()
@@ -40,25 +40,19 @@ class AssetLogModelTest(APIBaseTestCase):
     def test_verify_double_checkin_for_asset(self):
         # First log
         AssetLog.objects.create(
-            checked_by=self.security_user,
-            asset=self.test_other_asset,
-            log_type=CHECKIN,
+            checked_by=self.security_user, asset=self.test_other_asset, log_type=CHECKIN
         )
         initial_log_count = AssetLog.objects.count()
         # Second log
         AssetLog.objects.create(
-            checked_by=self.security_user,
-            asset=self.test_other_asset,
-            log_type=CHECKIN,
+            checked_by=self.security_user, asset=self.test_other_asset, log_type=CHECKIN
         )
         final_log_count = AssetLog.objects.count()
         self.assertEqual(initial_log_count, final_log_count)
 
     def test_add_checkin(self):
         AssetLog.objects.create(
-            checked_by=self.security_user,
-            asset=self.test_other_asset,
-            log_type=CHECKIN,
+            checked_by=self.security_user, asset=self.test_other_asset, log_type=CHECKIN
         )
         self.assertEqual(AssetLog.objects.count(), 3)
         created_log = AssetLog.objects.filter(asset=self.test_other_asset).first()
@@ -99,8 +93,8 @@ class AssetLogModelTest(APIBaseTestCase):
         self.assertEqual(
             e.exception.message_dict,
             {
-                'log_type': ['This field cannot be blank.'],
-                '__all__': ['Log type is required.'],
+                "log_type": ["This field cannot be blank."],
+                "__all__": ["Log type is required."],
             },
         )
 
@@ -126,7 +120,7 @@ class AssetLogModelTest(APIBaseTestCase):
     def test_non_authenticated_user_checkin_checkout(self):
         response = client.get(self.asset_logs_url)
         self.assertEqual(
-            response.data, {'detail': 'Authentication credentials were not provided.'}
+            response.data, {"detail": "Authentication credentials were not provided."}
         )
 
     def test_checkout_model_string_representation(self):
@@ -134,136 +128,134 @@ class AssetLogModelTest(APIBaseTestCase):
             str(self.checkin.asset.serial_number), self.asset.serial_number
         )
 
-    @patch('api.authentication.auth.verify_id_token')
+    @patch("api.authentication.auth.verify_id_token")
     def test_authenticated_normal_user_list_checkin_checkout(
         self, mock_verify_id_token
     ):
-        mock_verify_id_token.return_value = {'email': self.user.email}
+        mock_verify_id_token.return_value = {"email": self.user.email}
         response = client.get(
             self.asset_logs_url, HTTP_AUTHORIZATION="Token {}".format(self.token_user)
         )
         self.assertEqual(
             response.data,
-            {'detail': 'You do not have permission to perform this action.'},
+            {"detail": "You do not have permission to perform this action."},
         )
         self.assertEqual(response.status_code, 403)
 
-    @patch('api.authentication.auth.verify_id_token')
+    @patch("api.authentication.auth.verify_id_token")
     def test_authenticated_security_user_list_checkin_checkout(
         self, mock_verify_id_token
     ):
-        mock_verify_id_token.return_value = {'email': self.security_user.email}
+        mock_verify_id_token.return_value = {"email": self.security_user.email}
         response = client.get(
             self.asset_logs_url,
             HTTP_AUTHORIZATION="Token {}".format(self.token_checked_by),
         )
-        self.assertIn(self.checkout.id, response.data['results'][0].values())
-        self.assertEqual(len(response.data['results']), AssetLog.objects.count())
+        self.assertIn(self.checkout.id, response.data["results"][0].values())
+        self.assertEqual(len(response.data["results"]), AssetLog.objects.count())
         self.assertEqual(response.status_code, 200)
 
-    @patch('api.authentication.auth.verify_id_token')
+    @patch("api.authentication.auth.verify_id_token")
     def test_authenticated_admin_user_list_checkin_checkout(self, mock_verify_id_token):
-        mock_verify_id_token.return_value = {'email': self.admin_user.email}
+        mock_verify_id_token.return_value = {"email": self.admin_user.email}
         response = client.get(
             self.asset_logs_url, HTTP_AUTHORIZATION="Token {}".format(self.token_admin)
         )
-        self.assertIn(self.checkout.id, response.data['results'][0].values())
-        self.assertEqual(len(response.data['results']), AssetLog.objects.count())
+        self.assertIn(self.checkout.id, response.data["results"][0].values())
+        self.assertEqual(len(response.data["results"]), AssetLog.objects.count())
         self.assertEqual(response.status_code, 200)
 
-    @patch('api.authentication.auth.verify_id_token')
+    @patch("api.authentication.auth.verify_id_token")
     def test_authenticated_normal_user_create_checkin(self, mock_verify_id_token):
-        mock_verify_id_token.return_value = {'email': self.user.email}
+        mock_verify_id_token.return_value = {"email": self.user.email}
         response = client.get(
             self.asset_logs_url, HTTP_AUTHORIZATION="Token {}".format(self.token_user)
         )
         self.assertEqual(
             response.data,
-            {'detail': 'You do not have permission to perform this action.'},
+            {"detail": "You do not have permission to perform this action."},
         )
         self.assertEqual(response.status_code, 403)
 
-    @patch('api.authentication.auth.verify_id_token')
+    @patch("api.authentication.auth.verify_id_token")
     def test_authenticated_security_user_create_checkin(self, mock_verify_id_token):
-        mock_verify_id_token.return_value = {'email': self.security_user.email}
-        data = {'asset': self.test_other_asset.id, 'log_type': 'Checkin'}
+        mock_verify_id_token.return_value = {"email": self.security_user.email}
+        data = {"asset": self.test_other_asset.id, "log_type": "Checkin"}
         response = client.post(
             self.asset_logs_url,
             data,
             HTTP_AUTHORIZATION="Token {}".format(self.token_checked_by),
         )
         self.assertEqual(
-            response.data['asset'],
+            response.data["asset"],
             f"{self.test_other_asset.serial_number} - "
             f"{self.test_other_asset.asset_code}",
         )
         self.assertEqual(response.status_code, 201)
 
-    @patch('api.authentication.auth.verify_id_token')
+    @patch("api.authentication.auth.verify_id_token")
     def test_authenticated_security_user_cannot_double_checkin_an_asset(
         self, mock_verify_id_token
     ):
-        mock_verify_id_token.return_value = {'email': self.security_user.email}
+        mock_verify_id_token.return_value = {"email": self.security_user.email}
         AssetLog.objects.create(
-            checked_by=self.security_user,
-            asset=self.test_other_asset,
-            log_type=CHECKIN,
+            checked_by=self.security_user, asset=self.test_other_asset, log_type=CHECKIN
         )
         initial_log_count = AssetLog.objects.count()
-        data = {'asset': self.test_other_asset.id, 'log_type': CHECKIN}
+        data = {"asset": self.test_other_asset.id, "log_type": CHECKIN}
         response = client.post(
             self.asset_logs_url,
             data,
-            HTTP_AUTHORIZATION="Token {}".format(self.token_checked_by)
+            HTTP_AUTHORIZATION="Token {}".format(self.token_checked_by),
         )
         updated_log_count = AssetLog.objects.count()
         self.assertEquals(response.status_code, 400)
         self.assertEqual(initial_log_count, updated_log_count)
 
-    @patch('api.authentication.auth.verify_id_token')
+    @patch("api.authentication.auth.verify_id_token")
     def test_authenticated_security_user_create_checkout(self, mock_verify_id_token):
-        mock_verify_id_token.return_value = {'email': self.security_user.email}
-        data = {'asset': self.test_other_asset.id, 'log_type': CHECKOUT}
+        mock_verify_id_token.return_value = {"email": self.security_user.email}
+        data = {"asset": self.test_other_asset.id, "log_type": CHECKOUT}
         response = client.post(
             self.asset_logs_url,
             data,
             HTTP_AUTHORIZATION="Token {}".format(self.token_checked_by),
         )
         self.assertEqual(
-            response.data['asset'],
+            response.data["asset"],
             f"{self.test_other_asset.serial_number} - "
             f"{self.test_other_asset.asset_code}",
         )
         self.assertEqual(response.status_code, 201)
-    
-    @patch('api.authentication.auth.verify_id_token')
+
+    @patch("api.authentication.auth.verify_id_token")
     def test_authenticated_security_user_cannot_double_checkout_an_asset(
         self, mock_verify_id_token
     ):
-        mock_verify_id_token.return_value = {'email': self.security_user.email}
+        mock_verify_id_token.return_value = {"email": self.security_user.email}
         AssetLog.objects.create(
             checked_by=self.security_user,
             asset=self.test_other_asset,
             log_type=CHECKOUT,
         )
         initial_log_count = AssetLog.objects.count()
-        data = {'asset': self.test_other_asset.id, 'log_type': CHECKOUT}
+        data = {"asset": self.test_other_asset.id, "log_type": CHECKOUT}
         response = client.post(
             self.asset_logs_url,
             data,
-            HTTP_AUTHORIZATION="Token {}".format(self.token_checked_by)
+            HTTP_AUTHORIZATION="Token {}".format(self.token_checked_by),
         )
         updated_log_count = AssetLog.objects.count()
         self.assertEquals(response.status_code, 400)
         self.assertEqual(initial_log_count, updated_log_count)
 
-    @patch('api.authentication.auth.verify_id_token')
+    @patch("api.authentication.auth.verify_id_token")
     def test_authenticated_security_user_create_with_invalid_log_type(
         self, mock_verify_id_token
     ):
-        mock_verify_id_token.return_value = {'email': self.security_user.email}
+        mock_verify_id_token.return_value = {"email": self.security_user.email}
         log_type = "Invalid"
-        data = {'asset': self.test_other_asset.id, 'log_type': log_type}
+        data = {"asset": self.test_other_asset.id, "log_type": log_type}
         response = client.post(
             self.asset_logs_url,
             data,
@@ -271,66 +263,66 @@ class AssetLogModelTest(APIBaseTestCase):
         )
         self.assertEqual(
             response.data,
-            {'log_type': ['"{}" is not a valid choice.'.format(log_type)]},
+            {"log_type": ['"{}" is not a valid choice.'.format(log_type)]},
         )
         self.assertEqual(response.status_code, 400)
 
-    @patch('api.authentication.auth.verify_id_token')
+    @patch("api.authentication.auth.verify_id_token")
     def test_authenticated_security_user_create_checkin_without_asset(
         self, mock_verify_id_token
     ):
-        mock_verify_id_token.return_value = {'email': self.security_user.email}
-        data = {'log_type': 'Checkin'}
+        mock_verify_id_token.return_value = {"email": self.security_user.email}
+        data = {"log_type": "Checkin"}
         response = client.post(
             self.asset_logs_url,
             data,
             HTTP_AUTHORIZATION="Token {}".format(self.token_checked_by),
         )
-        self.assertDictEqual(response.data, {'asset': ['This field is required.']})
+        self.assertDictEqual(response.data, {"asset": ["This field is required."]})
         self.assertEqual(response.status_code, 400)
 
-    @patch('api.authentication.auth.verify_id_token')
+    @patch("api.authentication.auth.verify_id_token")
     def test_authenticated_security_user_view_checkin_detail(
         self, mock_verify_id_token
     ):
-        mock_verify_id_token.return_value = {'email': self.security_user.email}
+        mock_verify_id_token.return_value = {"email": self.security_user.email}
         response = client.get(
             "{}/{}/".format(self.asset_logs_url, self.checkin.id),
             HTTP_AUTHORIZATION="Token {}".format(self.token_checked_by),
         )
-        self.assertEqual(response.data['id'], self.checkin.id)
+        self.assertEqual(response.data["id"], self.checkin.id)
         self.assertEqual(response.status_code, 200)
 
-    @patch('api.authentication.auth.verify_id_token')
+    @patch("api.authentication.auth.verify_id_token")
     def test_authenticated_security_user_cannot_delete_checkin(
         self, mock_verify_id_token
     ):
-        mock_verify_id_token.return_value = {'email': self.security_user.email}
+        mock_verify_id_token.return_value = {"email": self.security_user.email}
         response = client.delete(
             "{}/{}/".format(self.asset_logs_url, self.checkin.id),
             HTTP_AUTHORIZATION="Token {}".format(self.token_checked_by),
         )
-        self.assertEqual(response.data, {'detail': 'Method "DELETE" not allowed.'})
+        self.assertEqual(response.data, {"detail": 'Method "DELETE" not allowed.'})
         self.assertEqual(response.status_code, 405)
 
-    @patch('api.authentication.auth.verify_id_token')
+    @patch("api.authentication.auth.verify_id_token")
     def test_authenticated_security_user_cannot_put_checkin(self, mock_verify_id_token):
-        mock_verify_id_token.return_value = {'email': self.security_user.email}
+        mock_verify_id_token.return_value = {"email": self.security_user.email}
         response = client.put(
             "{}/{}/".format(self.asset_logs_url, self.checkin.id),
             HTTP_AUTHORIZATION="Token {}".format(self.token_checked_by),
         )
-        self.assertEqual(response.data, {'detail': 'Method "PUT" not allowed.'})
+        self.assertEqual(response.data, {"detail": 'Method "PUT" not allowed.'})
         self.assertEqual(response.status_code, 405)
 
-    @patch('api.authentication.auth.verify_id_token')
+    @patch("api.authentication.auth.verify_id_token")
     def test_authenticated_security_user_cannot_patch_checkin(
         self, mock_verify_id_token
     ):
-        mock_verify_id_token.return_value = {'email': self.security_user.email}
+        mock_verify_id_token.return_value = {"email": self.security_user.email}
         response = client.patch(
             "{}/{}/".format(self.asset_logs_url, self.checkin.id),
             HTTP_AUTHORIZATION="Token {}".format(self.token_checked_by),
         )
-        self.assertEqual(response.data, {'detail': 'Method "PATCH" not allowed.'})
+        self.assertEqual(response.data, {"detail": 'Method "PATCH" not allowed.'})
         self.assertEqual(response.status_code, 405)

--- a/core/models/asset.py
+++ b/core/models/asset.py
@@ -147,6 +147,9 @@ class AssetModelNumber(models.Model):
 
     def save(self, *args, **kwargs):
         self.full_clean()
+        log = AssetLog.objects.filter(asset=self.asset).first()
+        if log and log.log_type == self.log_type:
+            return None
         super().save(*args, **kwargs)
 
     class Meta:

--- a/core/models/asset.py
+++ b/core/models/asset.py
@@ -360,6 +360,9 @@ class AssetLog(models.Model):
 
     def save(self, *args, **kwargs):
         self.full_clean()
+        log = AssetLog.objects.filter(asset=self.asset).first()
+        if log and log.log_type == self.log_type:
+            return None
         super().save(*args, **kwargs)
 
     class Meta:

--- a/core/models/asset.py
+++ b/core/models/asset.py
@@ -147,9 +147,6 @@ class AssetModelNumber(models.Model):
 
     def save(self, *args, **kwargs):
         self.full_clean()
-        log = AssetLog.objects.filter(asset=self.asset).first()
-        if log and log.log_type == self.log_type:
-            return None
         super().save(*args, **kwargs)
 
     class Meta:


### PR DESCRIPTION
 - Update test to check for log_type

 - Add test

#### What does this PR do?
Fixes a bug: Prevent checkin or checkout of an asset more than once


#### Description of Task to be completed?
* Update existing test
* Write new test
* Update save() to prevent checking in or checking out an asset more than once.

#### How should this be manually tested?
Run:
1. `python manage.py test api.tests.test_asset_log.AssetLogModelTest.test_verify_double_checkin_for_asset`

2. `python manage.py test api.tests.test_asset_log.AssetLogModelTest.test_verify_double_checkout_for_asset` 

#### Any background context you want to provide?
Formerly a security user could checkin an asset more than once or checkout an asset that has been checked out already.

#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/164726859