### PR TITLE
Bg double asset log #164726859

### DIFF
--- a/api/serializers/assets.py
+++ b/api/serializers/assets.py
@@ -14,7 +14,7 @@ class AssetSerializer(serializers.ModelSerializer):
     asset_category = serializers.ReadOnlyField()
     asset_sub_category = serializers.ReadOnlyField()
     asset_make = serializers.ReadOnlyField()
-    make_label = serializers.ReadOnlyField(source='asset_make')
+    make_label = serializers.ReadOnlyField(source="asset_make")
     asset_type = serializers.ReadOnlyField()
     asset_location = serializers.SlugRelatedField(
         many=False,
@@ -162,8 +162,10 @@ class AssetLogSerializer(serializers.ModelSerializer):
         return instance_data
 
     def validate(self, fields):
-        if models.AssetLog.objects.filter(**fields).exists():
-            raise serializers.ValidationError('Log for this asset already exist')
+        existing_log = models.AssetLog.objects.filter(asset=fields["asset"])
+        existing_log = existing_log.first()
+        if existing_log and existing_log.log_type == fields["log_type"]:
+            raise serializers.ValidationError("Log for this asset already exist")
         return fields
 
 
@@ -223,7 +225,7 @@ class AllocationsSerializer(serializers.ModelSerializer):
 
 
 class AssetCategorySerializer(serializers.ModelSerializer):
-    category_name = serializers.ReadOnlyField(source='name')
+    category_name = serializers.ReadOnlyField(source="name")
 
     class Meta:
         model = models.AssetCategory
@@ -238,7 +240,7 @@ class AssetCategorySerializer(serializers.ModelSerializer):
 
 
 class AssetSubCategorySerializer(serializers.ModelSerializer):
-    sub_category_name = serializers.ReadOnlyField(source='name')
+    sub_category_name = serializers.ReadOnlyField(source="name")
 
     class Meta:
         model = models.AssetSubCategory
@@ -265,7 +267,7 @@ class AssetSubCategorySerializer(serializers.ModelSerializer):
 
 
 class AssetTypeSerializer(serializers.ModelSerializer):
-    asset_type = serializers.ReadOnlyField(source='name')
+    asset_type = serializers.ReadOnlyField(source="name")
 
     class Meta:
         model = models.AssetType
@@ -294,7 +296,7 @@ class AssetTypeSerializer(serializers.ModelSerializer):
 
 class AssetModelNumberSerializer(serializers.ModelSerializer):
     make_label = serializers.SerializerMethodField()
-    model_number = serializers.ReadOnlyField(source='name')
+    model_number = serializers.ReadOnlyField(source="name")
 
     class Meta:
         model = models.AssetModelNumber
@@ -425,8 +427,8 @@ class AssetIncidentReportSerializer(serializers.ModelSerializer):
 
 class AssetHealthSerializer(serializers.ModelSerializer):
     asset_type = serializers.ReadOnlyField()
-    model_number = serializers.ReadOnlyField(source='model_number__name')
-    count_by_status = serializers.ReadOnlyField(source='current_status')
+    model_number = serializers.ReadOnlyField(source="model_number__name")
+    count_by_status = serializers.ReadOnlyField(source="current_status")
 
     class Meta:
         model = models.Asset

--- a/api/tests/test_asset_log.py
+++ b/api/tests/test_asset_log.py
@@ -84,21 +84,6 @@ class AssetLogModelTest(APIBaseTestCase):
         )
         self.assertEqual(AssetLog.objects.count(), count_before_log + 1)
 
-    def test_verify_double_checkout_for_asset(self):
-        # First log
-        AssetLog.objects.create(
-            checked_by=self.security_user,
-            asset=self.test_other_asset,
-            log_type="Checkout",
-        )
-        # Second log
-        AssetLog.objects.create(
-            checked_by=self.security_user,
-            asset=self.test_other_asset,
-            log_type="Checkout",
-        )
-        self.assertEqual(AssetLog.objects.count(), 3)
-
     def test_add_checkin_without_log_type(self):
         with self.assertRaises(ValidationError) as e:
             AssetLog.objects.create(

--- a/api/tests/test_asset_log.py
+++ b/api/tests/test_asset_log.py
@@ -10,6 +10,7 @@ from rest_framework.test import APIClient
 from api.tests import APIBaseTestCase
 from core.constants import CHECKIN, CHECKOUT
 from core.models import Asset, AssetLog, AssetModelNumber
+from core.constants import CHECKIN, CHECKOUT
 
 User = get_user_model()
 client = APIClient()
@@ -40,19 +41,25 @@ class AssetLogModelTest(APIBaseTestCase):
     def test_verify_double_checkin_for_asset(self):
         # First log
         AssetLog.objects.create(
-            checked_by=self.security_user, asset=self.test_other_asset, log_type=CHECKIN
+            checked_by=self.security_user,
+            asset=self.test_other_asset,
+            log_type=CHECKIN,
         )
         initial_log_count = AssetLog.objects.count()
         # Second log
         AssetLog.objects.create(
-            checked_by=self.security_user, asset=self.test_other_asset, log_type=CHECKIN
+            checked_by=self.security_user,
+            asset=self.test_other_asset,
+            log_type=CHECKIN,
         )
         final_log_count = AssetLog.objects.count()
         self.assertEqual(initial_log_count, final_log_count)
 
     def test_add_checkin(self):
         AssetLog.objects.create(
-            checked_by=self.security_user, asset=self.test_other_asset, log_type=CHECKIN
+            checked_by=self.security_user,
+            asset=self.test_other_asset,
+            log_type=CHECKIN,
         )
         self.assertEqual(AssetLog.objects.count(), 3)
         created_log = AssetLog.objects.filter(asset=self.test_other_asset).first()
@@ -193,29 +200,31 @@ class AssetLogModelTest(APIBaseTestCase):
         )
         self.assertEqual(response.status_code, 201)
 
-    @patch("api.authentication.auth.verify_id_token")
+    @patch('api.authentication.auth.verify_id_token')
     def test_authenticated_security_user_cannot_double_checkin_an_asset(
         self, mock_verify_id_token
     ):
-        mock_verify_id_token.return_value = {"email": self.security_user.email}
+        mock_verify_id_token.return_value = {'email': self.security_user.email}
         AssetLog.objects.create(
-            checked_by=self.security_user, asset=self.test_other_asset, log_type=CHECKIN
+            checked_by=self.security_user,
+            asset=self.test_other_asset,
+            log_type=CHECKIN,
         )
         initial_log_count = AssetLog.objects.count()
-        data = {"asset": self.test_other_asset.id, "log_type": CHECKIN}
+        data = {'asset': self.test_other_asset.id, 'log_type': CHECKIN}
         response = client.post(
             self.asset_logs_url,
             data,
-            HTTP_AUTHORIZATION="Token {}".format(self.token_checked_by),
+            HTTP_AUTHORIZATION="Token {}".format(self.token_checked_by)
         )
         updated_log_count = AssetLog.objects.count()
         self.assertEquals(response.status_code, 400)
         self.assertEqual(initial_log_count, updated_log_count)
 
-    @patch("api.authentication.auth.verify_id_token")
+    @patch('api.authentication.auth.verify_id_token')
     def test_authenticated_security_user_create_checkout(self, mock_verify_id_token):
-        mock_verify_id_token.return_value = {"email": self.security_user.email}
-        data = {"asset": self.test_other_asset.id, "log_type": CHECKOUT}
+        mock_verify_id_token.return_value = {'email': self.security_user.email}
+        data = {'asset': self.test_other_asset.id, 'log_type': CHECKOUT}
         response = client.post(
             self.asset_logs_url,
             data,
@@ -227,6 +236,27 @@ class AssetLogModelTest(APIBaseTestCase):
             f"{self.test_other_asset.asset_code}",
         )
         self.assertEqual(response.status_code, 201)
+    
+    @patch('api.authentication.auth.verify_id_token')
+    def test_authenticated_security_user_cannot_double_checkout_an_asset(
+        self, mock_verify_id_token
+    ):
+        mock_verify_id_token.return_value = {'email': self.security_user.email}
+        AssetLog.objects.create(
+            checked_by=self.security_user,
+            asset=self.test_other_asset,
+            log_type=CHECKOUT,
+        )
+        initial_log_count = AssetLog.objects.count()
+        data = {'asset': self.test_other_asset.id, 'log_type': CHECKOUT}
+        response = client.post(
+            self.asset_logs_url,
+            data,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_checked_by)
+        )
+        updated_log_count = AssetLog.objects.count()
+        self.assertEquals(response.status_code, 400)
+        self.assertEqual(initial_log_count, updated_log_count)
 
     @patch("api.authentication.auth.verify_id_token")
     def test_authenticated_security_user_cannot_double_checkout_an_asset(

--- a/api/tests/test_asset_log.py
+++ b/api/tests/test_asset_log.py
@@ -84,6 +84,21 @@ class AssetLogModelTest(APIBaseTestCase):
         )
         self.assertEqual(AssetLog.objects.count(), count_before_log + 1)
 
+    def test_verify_double_checkout_for_asset(self):
+        # First log
+        AssetLog.objects.create(
+            checked_by=self.security_user,
+            asset=self.test_other_asset,
+            log_type="Checkout",
+        )
+        # Second log
+        AssetLog.objects.create(
+            checked_by=self.security_user,
+            asset=self.test_other_asset,
+            log_type="Checkout",
+        )
+        self.assertEqual(AssetLog.objects.count(), 3)
+
     def test_add_checkin_without_log_type(self):
         with self.assertRaises(ValidationError) as e:
             AssetLog.objects.create(

--- a/api/tests/test_asset_log.py
+++ b/api/tests/test_asset_log.py
@@ -10,7 +10,6 @@ from rest_framework.test import APIClient
 from api.tests import APIBaseTestCase
 from core.constants import CHECKIN, CHECKOUT
 from core.models import Asset, AssetLog, AssetModelNumber
-from core.constants import CHECKIN, CHECKOUT
 
 User = get_user_model()
 client = APIClient()
@@ -41,25 +40,19 @@ class AssetLogModelTest(APIBaseTestCase):
     def test_verify_double_checkin_for_asset(self):
         # First log
         AssetLog.objects.create(
-            checked_by=self.security_user,
-            asset=self.test_other_asset,
-            log_type=CHECKIN,
+            checked_by=self.security_user, asset=self.test_other_asset, log_type=CHECKIN
         )
         initial_log_count = AssetLog.objects.count()
         # Second log
         AssetLog.objects.create(
-            checked_by=self.security_user,
-            asset=self.test_other_asset,
-            log_type=CHECKIN,
+            checked_by=self.security_user, asset=self.test_other_asset, log_type=CHECKIN
         )
         final_log_count = AssetLog.objects.count()
         self.assertEqual(initial_log_count, final_log_count)
 
     def test_add_checkin(self):
         AssetLog.objects.create(
-            checked_by=self.security_user,
-            asset=self.test_other_asset,
-            log_type=CHECKIN,
+            checked_by=self.security_user, asset=self.test_other_asset, log_type=CHECKIN
         )
         self.assertEqual(AssetLog.objects.count(), 3)
         created_log = AssetLog.objects.filter(asset=self.test_other_asset).first()
@@ -200,31 +193,29 @@ class AssetLogModelTest(APIBaseTestCase):
         )
         self.assertEqual(response.status_code, 201)
 
-    @patch('api.authentication.auth.verify_id_token')
+    @patch("api.authentication.auth.verify_id_token")
     def test_authenticated_security_user_cannot_double_checkin_an_asset(
         self, mock_verify_id_token
     ):
-        mock_verify_id_token.return_value = {'email': self.security_user.email}
+        mock_verify_id_token.return_value = {"email": self.security_user.email}
         AssetLog.objects.create(
-            checked_by=self.security_user,
-            asset=self.test_other_asset,
-            log_type=CHECKIN,
+            checked_by=self.security_user, asset=self.test_other_asset, log_type=CHECKIN
         )
         initial_log_count = AssetLog.objects.count()
-        data = {'asset': self.test_other_asset.id, 'log_type': CHECKIN}
+        data = {"asset": self.test_other_asset.id, "log_type": CHECKIN}
         response = client.post(
             self.asset_logs_url,
             data,
-            HTTP_AUTHORIZATION="Token {}".format(self.token_checked_by)
+            HTTP_AUTHORIZATION="Token {}".format(self.token_checked_by),
         )
         updated_log_count = AssetLog.objects.count()
         self.assertEquals(response.status_code, 400)
         self.assertEqual(initial_log_count, updated_log_count)
 
-    @patch('api.authentication.auth.verify_id_token')
+    @patch("api.authentication.auth.verify_id_token")
     def test_authenticated_security_user_create_checkout(self, mock_verify_id_token):
-        mock_verify_id_token.return_value = {'email': self.security_user.email}
-        data = {'asset': self.test_other_asset.id, 'log_type': CHECKOUT}
+        mock_verify_id_token.return_value = {"email": self.security_user.email}
+        data = {"asset": self.test_other_asset.id, "log_type": CHECKOUT}
         response = client.post(
             self.asset_logs_url,
             data,
@@ -236,27 +227,6 @@ class AssetLogModelTest(APIBaseTestCase):
             f"{self.test_other_asset.asset_code}",
         )
         self.assertEqual(response.status_code, 201)
-    
-    @patch('api.authentication.auth.verify_id_token')
-    def test_authenticated_security_user_cannot_double_checkout_an_asset(
-        self, mock_verify_id_token
-    ):
-        mock_verify_id_token.return_value = {'email': self.security_user.email}
-        AssetLog.objects.create(
-            checked_by=self.security_user,
-            asset=self.test_other_asset,
-            log_type=CHECKOUT,
-        )
-        initial_log_count = AssetLog.objects.count()
-        data = {'asset': self.test_other_asset.id, 'log_type': CHECKOUT}
-        response = client.post(
-            self.asset_logs_url,
-            data,
-            HTTP_AUTHORIZATION="Token {}".format(self.token_checked_by)
-        )
-        updated_log_count = AssetLog.objects.count()
-        self.assertEquals(response.status_code, 400)
-        self.assertEqual(initial_log_count, updated_log_count)
 
     @patch("api.authentication.auth.verify_id_token")
     def test_authenticated_security_user_cannot_double_checkout_an_asset(

--- a/api/views/assets.py
+++ b/api/views/assets.py
@@ -411,7 +411,7 @@ class AssetsImportViewSet(APIView):
         error = False
         file_obj = codecs.iterdecode(file_object, "utf-8")
         csv_reader = DictReaderStrip(file_obj, delimiter=",")
-        print('Processing uploaded file:')
+        print("Processing uploaded file:")
         if not process_file(csv_reader, user=user):
             path = request.build_absolute_uri(reverse("skipped"))
             print("path in main end point", path)
@@ -479,7 +479,7 @@ class ExportAssetsDetails(APIView):
         for key, val in dict(request.query_params).items():
             lookup = functools.reduce(
                 operator.or_,
-                {Q(**{'__'.join([key, 'icontains']): item}) for item in val},
+                {Q(**{"__".join([key, "icontains"]): item}) for item in val},
             )
             filters |= lookup
         try:

--- a/core/models/asset.py
+++ b/core/models/asset.py
@@ -147,6 +147,9 @@ class AssetModelNumber(models.Model):
 
     def save(self, *args, **kwargs):
         self.full_clean()
+        log = AssetLog.objects.filter(asset=self.asset).first()
+        if log and log.log_type == self.log_type:
+            return None
         super().save(*args, **kwargs)
 
     class Meta:

--- a/core/models/asset.py
+++ b/core/models/asset.py
@@ -32,7 +32,7 @@ class AssetCategory(models.Model):
 
     def clean(self):
         if not self.name:
-            raise ValidationError('Category is required')
+            raise ValidationError("Category is required")
 
         self.name = self.name.title()
 
@@ -41,8 +41,8 @@ class AssetCategory(models.Model):
         super().save(*args, **kwargs)
 
     class Meta:
-        verbose_name_plural = 'Asset Categories'
-        ordering = ['-id']
+        verbose_name_plural = "Asset Categories"
+        ordering = ["-id"]
 
     def __str__(self):
         return self.name
@@ -60,7 +60,7 @@ class AssetSubCategory(models.Model):
 
     def clean(self):
         if not self.asset_category:
-            raise ValidationError('Category is required')
+            raise ValidationError("Category is required")
 
         self.name = self.name.title()
 
@@ -69,8 +69,8 @@ class AssetSubCategory(models.Model):
         super().save(*args, **kwargs)
 
     class Meta:
-        verbose_name_plural = 'Asset SubCategories'
-        ordering = ['-id']
+        verbose_name_plural = "Asset SubCategories"
+        ordering = ["-id"]
 
     def __str__(self):
         return self.name
@@ -89,7 +89,7 @@ class AssetType(models.Model):
 
     def clean(self):
         if not self.asset_sub_category:
-            raise ValidationError('Sub category is required')
+            raise ValidationError("Sub category is required")
 
         self.name = self.name.title()
 
@@ -99,7 +99,7 @@ class AssetType(models.Model):
 
     class Meta:
         verbose_name = "Asset Type"
-        ordering = ['-id']
+        ordering = ["-id"]
 
     def __str__(self):
         return self.name
@@ -117,7 +117,7 @@ class AssetMake(models.Model):
 
     def clean(self):
         if not self.asset_type:
-            raise ValidationError('Type is required')
+            raise ValidationError("Type is required")
 
         self.name = self.name.title()
 
@@ -127,7 +127,7 @@ class AssetMake(models.Model):
 
     class Meta:
         verbose_name = "Asset Make"
-        ordering = ['-id']
+        ordering = ["-id"]
 
     def __str__(self):
         return self.name
@@ -151,7 +151,7 @@ class AssetModelNumber(models.Model):
 
     class Meta:
         verbose_name = "Asset Model Number"
-        ordering = ['-id']
+        ordering = ["-id"]
 
     def __str__(self):
         return self.name
@@ -191,7 +191,7 @@ class AssetSpecs(models.Model):
         super().save(*args, **kwargs)
 
     def __str__(self):
-        return f"{self.memory}GB RAM, {self.storage}GB, {self.processor_speed}GHz, {self.screen_size}\""
+        return f'{self.memory}GB RAM, {self.storage}GB, {self.processor_speed}GHz, {self.screen_size}"'
 
 
 class Asset(models.Model):
@@ -202,12 +202,12 @@ class Asset(models.Model):
     serial_number = models.CharField(unique=True, null=True, blank=True, max_length=50)
     created_at = models.DateTimeField(auto_now_add=True, editable=False)
     asset_location = models.ForeignKey(
-        'AndelaCentre', blank=True, null=True, on_delete=models.PROTECT
+        "AndelaCentre", blank=True, null=True, on_delete=models.PROTECT
     )
     purchase_date = models.DateField(validators=[validate_date], null=True, blank=True)
     last_modified = models.DateTimeField(auto_now=True, editable=False)
     assigned_to = models.ForeignKey(
-        'AssetAssignee', blank=True, editable=False, null=True, on_delete=models.PROTECT
+        "AssetAssignee", blank=True, editable=False, null=True, on_delete=models.PROTECT
     )
     model_number = models.ForeignKey(
         AssetModelNumber, null=True, on_delete=models.PROTECT
@@ -221,20 +221,20 @@ class Asset(models.Model):
     objects = CaseInsensitiveManager()
 
     def __str__(self):
-        return '{}, {}, {}'.format(
+        return "{}, {}, {}".format(
             self.asset_code, self.serial_number, self.model_number
         )
 
     class Meta:
-        ordering = ['-id']
+        ordering = ["-id"]
         unique_together = ("asset_code", "serial_number")
-        indexes = [models.Index(fields=['current_status', 'verified'])]
+        indexes = [models.Index(fields=["current_status", "verified"])]
 
     def clean(self):
         if not self.asset_code and not self.serial_number:
             raise ValidationError(
-                ('Please provide either the serial number, asset code or both.'),
-                code='required',
+                ("Please provide either the serial number, asset code or both."),
+                code="required",
             )
 
         if self.serial_number is None:
@@ -298,12 +298,12 @@ class Asset(models.Model):
 
 class AssetAssignee(models.Model):
     department = models.OneToOneField(
-        'Department', null=True, blank=True, on_delete=models.CASCADE
+        "Department", null=True, blank=True, on_delete=models.CASCADE
     )
     workspace = models.OneToOneField(
-        'OfficeWorkspace', null=True, blank=True, on_delete=models.CASCADE
+        "OfficeWorkspace", null=True, blank=True, on_delete=models.CASCADE
     )
-    user = models.OneToOneField('User', null=True, blank=True, on_delete=models.CASCADE)
+    user = models.OneToOneField("User", null=True, blank=True, on_delete=models.CASCADE)
 
     def __str__(self):
         assignee = self.workspace or self.department or self.user
@@ -315,7 +315,7 @@ class AssetAssignee(models.Model):
             )
 
     class Meta:
-        ordering = ['-id']
+        ordering = ["-id"]
 
     @property
     def first_name(self):
@@ -356,7 +356,7 @@ class AssetLog(models.Model):
 
     def clean(self):
         if not self.log_type:
-            raise ValidationError('Log type is required.', code='required')
+            raise ValidationError("Log type is required.", code="required")
 
     def save(self, *args, **kwargs):
         self.full_clean()
@@ -367,7 +367,7 @@ class AssetLog(models.Model):
 
     class Meta:
         verbose_name = "Asset Log"
-        ordering = ['-id']
+        ordering = ["-id"]
 
 
 class AssetStatus(models.Model):
@@ -387,13 +387,13 @@ class AssetStatus(models.Model):
     created_at = models.DateTimeField(auto_now_add=True, editable=False)
 
     class Meta:
-        verbose_name_plural = 'Asset Statuses'
-        ordering = ['-id']
+        verbose_name_plural = "Asset Statuses"
+        ordering = ["-id"]
 
     def save(self, *args, **kwargs):
         try:
             latest_record = AssetStatus.objects.filter(asset=self.asset).latest(
-                'created_at'
+                "created_at"
             )
             self.previous_status = latest_record.current_status
         except Exception:
@@ -419,9 +419,9 @@ class AssetStatus(models.Model):
         """Check the assets have not exceeded the limit"""
         model_number = self.asset.model_number
         available_assets = Asset.objects.filter(
-            current_status='Available', model_number=model_number
+            current_status="Available", model_number=model_number
         ).count()
-        if available_assets <= int(os.environ.get('ASSET_LIMIT', 0)):
+        if available_assets <= int(os.environ.get("ASSET_LIMIT", 0)):
             message = "Warning!! The number of available {} ".format(
                 model_number
             ) + " is {}".format(available_assets)
@@ -431,7 +431,7 @@ class AssetStatus(models.Model):
         try:
             last_allocation_record = AllocationHistory.objects.filter(
                 asset=self.asset
-            ).latest('created_at')
+            ).latest("created_at")
         except Exception as e:
             logger.warning(str(e))
         else:
@@ -446,15 +446,15 @@ class AssetStatus(models.Model):
 class AllocationHistory(models.Model):
     asset = models.ForeignKey(Asset, on_delete=models.PROTECT)
     current_owner = models.ForeignKey(
-        'AssetAssignee',
-        related_name='current_owner_asset',
+        "AssetAssignee",
+        related_name="current_owner_asset",
         blank=True,
         null=True,
         on_delete=models.PROTECT,
     )
     previous_owner = models.ForeignKey(
-        'AssetAssignee',
-        related_name='previous_owner_asset',
+        "AssetAssignee",
+        related_name="previous_owner_asset",
         editable=False,
         blank=True,
         null=True,
@@ -464,7 +464,7 @@ class AllocationHistory(models.Model):
 
     class Meta:
         verbose_name_plural = "Allocation History"
-        ordering = ['-id']
+        ordering = ["-id"]
 
     def clean(self):
         if self.asset.current_status != constants.AVAILABLE:
@@ -474,7 +474,7 @@ class AllocationHistory(models.Model):
         self.full_clean()
         try:
             latest_record = AllocationHistory.objects.filter(asset=self.asset).latest(
-                'created_at'
+                "created_at"
             )
             self.previous_owner = latest_record.current_owner
         except Exception:
@@ -491,7 +491,7 @@ class AllocationHistory(models.Model):
             self._send_notification()
 
     def _create_asset_status_when_asset_is_allocated(self):
-        last_status = AssetStatus.objects.filter(asset=self.asset).latest('created_at')
+        last_status = AssetStatus.objects.filter(asset=self.asset).latest("created_at")
         if self.current_owner:
             AssetStatus.objects.create(
                 asset=self.asset,
@@ -505,12 +505,12 @@ class AllocationHistory(models.Model):
         serial_no = asset.serial_number
         asset_code = asset.asset_code
 
-        env_message = ' *_(this is a test message.)_*' if settings.DEBUG else ''
-        serial_no = f'Serial Number {serial_no} ' if serial_no else ''
-        asset_code = f'Asset Code {asset_code} ' if asset_code else ''
-        _and = f'and ' if asset_code and serial_no else ''
-        message = f'The {asset.asset_type} with {serial_no}{_and}{asset_code}'
-        to_append = 'Please contact the Ops team if this information is inaccurate.'
+        env_message = " *_(this is a test message.)_*" if settings.DEBUG else ""
+        serial_no = f"Serial Number {serial_no} " if serial_no else ""
+        asset_code = f"Asset Code {asset_code} " if asset_code else ""
+        _and = f"and " if asset_code and serial_no else ""
+        message = f"The {asset.asset_type} with {serial_no}{_and}{asset_code}"
+        to_append = "Please contact the Ops team if this information is inaccurate."
 
         if asset.assigned_to and asset.current_status == constants.ALLOCATED:
             message += "has been allocated to you. {} {}".format(to_append, env_message)
@@ -521,7 +521,7 @@ class AllocationHistory(models.Model):
             )
             assignee = self.previous_owner
 
-        if assignee and hasattr(assignee, 'email'):
+        if assignee and hasattr(assignee, "email"):
             slack.send_message(message, user=assignee.user)
 
 
@@ -531,8 +531,8 @@ class AssetCondition(models.Model):
     created_at = models.DateTimeField(auto_now_add=True, editable=False)
 
     class Meta:
-        verbose_name_plural = 'Asset Condition'
-        ordering = ['-id']
+        verbose_name_plural = "Asset Condition"
+        ordering = ["-id"]
 
     def save(self, *args, **kwargs):
         try:
@@ -558,13 +558,13 @@ class AssetIncidentReport(models.Model):
     loss_of_property = models.TextField(null=True, blank=True)
     witnesses = models.TextField(null=True, blank=True)
     police_abstract_obtained = models.CharField(max_length=255)
-    submitted_by = models.ForeignKey('User', null=True, on_delete=models.PROTECT)
+    submitted_by = models.ForeignKey("User", null=True, on_delete=models.PROTECT)
 
     def __str__(self):
         return f"{self.incident_type}: {self.asset}"
 
     class Meta:
-        ordering = ['-id']
+        ordering = ["-id"]
 
     def save(self, *args, **kwargs):
         try:
@@ -590,4 +590,4 @@ class StateTransition(models.Model):
     state = models.CharField(max_length=50, default=constants.NEWLY_REPORTED)
 
     class Meta:
-        verbose_name_plural = 'State Transitions'
+        verbose_name_plural = "State Transitions"

--- a/core/models/asset.py
+++ b/core/models/asset.py
@@ -147,9 +147,6 @@ class AssetModelNumber(models.Model):
 
     def save(self, *args, **kwargs):
         self.full_clean()
-        log = AssetLog.objects.filter(asset=self.asset).first()
-        if log and log.log_type == self.log_type:
-            return None
         super().save(*args, **kwargs)
 
     class Meta:


### PR DESCRIPTION
#### What does this PR do?
Fix a bug that prevents authorized users from checkin in an asset once checked in and vise versa

#### Description of Task to be completed?
* Write test to check this behaviour
* update the validate method to fix the issue

#### How should this be manually tested?
1. Create an asset log for checkin
2. Create log for same asset and set log_type to checkout
3. Create log for same asset and set log_type to checkin again.


#### Any background context you want to provide?
You could previously checkin and then checkout an asset. An authorized user can not checkin that asset again.

#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/165215396