### PR TITLE
Fix: Allow assetlog once created to be recreated with appropriate log…

### DIFF
--- a/api/serializers/assets.py
+++ b/api/serializers/assets.py
@@ -14,7 +14,7 @@ class AssetSerializer(serializers.ModelSerializer):
     asset_category = serializers.ReadOnlyField()
     asset_sub_category = serializers.ReadOnlyField()
     asset_make = serializers.ReadOnlyField()
-    make_label = serializers.ReadOnlyField(source='asset_make')
+    make_label = serializers.ReadOnlyField(source="asset_make")
     asset_type = serializers.ReadOnlyField()
     asset_location = serializers.SlugRelatedField(
         many=False,
@@ -166,7 +166,8 @@ class AssetLogSerializer(serializers.ModelSerializer):
         existing_log = existing_log.first()
         if existing_log and existing_log.log_type == fields["log_type"]:
             raise serializers.ValidationError(
-                f"The asset log type is already {existing_log.log_type}")
+                f"The asset log type is already {existing_log.log_type}"
+            )
         return fields
 
 
@@ -226,7 +227,7 @@ class AllocationsSerializer(serializers.ModelSerializer):
 
 
 class AssetCategorySerializer(serializers.ModelSerializer):
-    category_name = serializers.ReadOnlyField(source='name')
+    category_name = serializers.ReadOnlyField(source="name")
 
     class Meta:
         model = models.AssetCategory
@@ -241,7 +242,7 @@ class AssetCategorySerializer(serializers.ModelSerializer):
 
 
 class AssetSubCategorySerializer(serializers.ModelSerializer):
-    sub_category_name = serializers.ReadOnlyField(source='name')
+    sub_category_name = serializers.ReadOnlyField(source="name")
 
     class Meta:
         model = models.AssetSubCategory
@@ -268,7 +269,7 @@ class AssetSubCategorySerializer(serializers.ModelSerializer):
 
 
 class AssetTypeSerializer(serializers.ModelSerializer):
-    asset_type = serializers.ReadOnlyField(source='name')
+    asset_type = serializers.ReadOnlyField(source="name")
 
     class Meta:
         model = models.AssetType
@@ -297,7 +298,7 @@ class AssetTypeSerializer(serializers.ModelSerializer):
 
 class AssetModelNumberSerializer(serializers.ModelSerializer):
     make_label = serializers.SerializerMethodField()
-    model_number = serializers.ReadOnlyField(source='name')
+    model_number = serializers.ReadOnlyField(source="name")
 
     class Meta:
         model = models.AssetModelNumber
@@ -428,8 +429,8 @@ class AssetIncidentReportSerializer(serializers.ModelSerializer):
 
 class AssetHealthSerializer(serializers.ModelSerializer):
     asset_type = serializers.ReadOnlyField()
-    model_number = serializers.ReadOnlyField(source='model_number__name')
-    count_by_status = serializers.ReadOnlyField(source='current_status')
+    model_number = serializers.ReadOnlyField(source="model_number__name")
+    count_by_status = serializers.ReadOnlyField(source="current_status")
 
     class Meta:
         model = models.Asset

--- a/api/serializers/assets.py
+++ b/api/serializers/assets.py
@@ -162,8 +162,11 @@ class AssetLogSerializer(serializers.ModelSerializer):
         return instance_data
 
     def validate(self, fields):
-        if models.AssetLog.objects.filter(**fields).exists():
-            raise serializers.ValidationError('Log for this asset already exist')
+        existing_log = models.AssetLog.objects.filter(asset=fields["asset"])
+        existing_log = existing_log.first()
+        if existing_log and existing_log.log_type == fields["log_type"]:
+            raise serializers.ValidationError(
+                f"The asset log type is already {existing_log.log_type}")
         return fields
 
 


### PR DESCRIPTION
### What does this PR do?
Fix a bug that prevents authorized users from checkin in an asset once checked in and vise versa

### Description of Task to be completed?
* Write test to check this behaviour
* update the validate method to fix the issue

### How should this be manually tested?
1. Create an asset log for checkin
2. Create log for same asset and set log_type to checkout
3. Create log for same asset and set log_type to checkin again.


### Any background context you want to provide?
You could previously checkin and then checkout an asset. An authorized user can not checkin that asset again.

### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/165215396