### PR TITLE
feature: filter asset logs by asset types-#164827041

### DIFF
--- a/api/filters.py
+++ b/api/filters.py
@@ -74,11 +74,12 @@ class AssetFilter(BaseFilter):
 class AssetLogFilter(BaseFilter):
     asset_type = filters.CharFilter(
         field_name="asset__model_number__asset_make__asset_type__name",
-        lookup_expr="iexact"
+        lookup_expr="iexact",
     )
+
     class Meta:
         model = AssetLog
-        fields = ['asset_type']
+        fields = ["asset_type"]
 
 
 class UserFilter(BaseFilter):

--- a/api/filters.py
+++ b/api/filters.py
@@ -8,7 +8,7 @@ from django.db.models import Q
 from django_filters import rest_framework as filters
 
 # App Imports
-from core.models import Asset, User
+from core.models import Asset, AssetLog, User
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +69,16 @@ class AssetFilter(BaseFilter):
     class Meta:
         model = Asset
         fields = ['asset_type', 'model_number', 'email', 'current_status', 'verified']
+
+
+class AssetLogFilter(BaseFilter):
+    asset_type = filters.CharFilter(
+        field_name="asset__model_number__asset_make__asset_type__name",
+        lookup_expr="iexact"
+    )
+    class Meta:
+        model = AssetLog
+        fields = ['asset_type']
 
 
 class UserFilter(BaseFilter):

--- a/api/tests/__init__.py
+++ b/api/tests/__init__.py
@@ -135,6 +135,9 @@ class APIBaseTestCase(TestCase):
         cls.asset_type = apps.get_model("core", "AssetType").objects.create(
             name="Asset Types", asset_sub_category=cls.asset_sub_category
         )
+        cls.test_asset_type = apps.get_model("core", "AssetType").objects.create(
+            name="Other Asset Types", asset_sub_category=cls.asset_sub_category
+        )
         cls.asset_make = apps.get_model("core", "AssetMake").objects.create(
             name="Asset Makes", asset_type=cls.asset_type
         )

--- a/api/tests/test_asset_log.py
+++ b/api/tests/test_asset_log.py
@@ -239,10 +239,10 @@ class AssetLogModelTest(APIBaseTestCase):
         )
         asset_logs_url = f"{self.asset_logs_url}/?asset_type=filterdontexit"
         response = client.get(
-            self.asset_logs_url, HTTP_AUTHORIZATION=f"Token {self.token_admin}"
+            asset_logs_url, HTTP_AUTHORIZATION=f"Token {self.token_admin}"
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data["results"]), AssetLog.objects.count())
+        self.assertEqual(len(response.data["results"]), 0)
 
     @patch("api.authentication.auth.verify_id_token")
     def test_authenticated_normal_user_create_checkin(self, mock_verify_id_token):

--- a/api/tests/test_asset_type_api.py
+++ b/api/tests/test_asset_type_api.py
@@ -17,12 +17,12 @@ class AssetCategoryAPITest(APIBaseTestCase):
     def test_non_authenticated_user_get_asset_sub_category(self):
         response = client.get(self.asset_type_url)
         self.assertEqual(
-            response.data, {'detail': 'Authentication credentials were not provided.'}
+            response.data, {"detail": "Authentication credentials were not provided."}
         )
 
-    @patch('api.authentication.auth.verify_id_token')
+    @patch("api.authentication.auth.verify_id_token")
     def test_can_post_asset_type(self, mock_verify_token):
-        mock_verify_token.return_value = {'email': self.admin_user.email}
+        mock_verify_token.return_value = {"email": self.admin_user.email}
         data = {
             "name": "Asset Type Example",
             "asset_sub_category": self.asset_sub_category.id,
@@ -36,20 +36,20 @@ class AssetCategoryAPITest(APIBaseTestCase):
         self.assertIn(data["name"], response.data.values())
         self.assertEqual(response.status_code, 201)
 
-    @patch('api.authentication.auth.verify_id_token')
+    @patch("api.authentication.auth.verify_id_token")
     def test_can_get_all_asset_types(self, mock_verify_token):
-        mock_verify_token.return_value = {'email': self.admin_user.email}
+        mock_verify_token.return_value = {"email": self.admin_user.email}
         response = client.get(
             self.asset_type_url, HTTP_AUTHORIZATION="Token {}".format(self.token_admin)
         )
 
-        self.assertEqual(len(response.data['results']), AssetCategory.objects.count())
-        self.assertIn("name", response.data['results'][0].keys())
+        self.assertEqual(len(response.data["results"]), AssetType.objects.count())
+        self.assertIn("name", response.data["results"][0].keys())
         self.assertEqual(response.status_code, 200)
 
-    @patch('api.authentication.auth.verify_id_token')
+    @patch("api.authentication.auth.verify_id_token")
     def test_can_get_single_asset_type(self, mock_verify_token):
-        mock_verify_token.return_value = {'email': self.admin_user.email}
+        mock_verify_token.return_value = {"email": self.admin_user.email}
         response = client.get(
             f"{self.asset_type_url}/{self.asset_type.id}/",
             HTTP_AUTHORIZATION="Token {}".format(self.token_admin),
@@ -59,44 +59,44 @@ class AssetCategoryAPITest(APIBaseTestCase):
         self.assertIn(self.asset_type.name, response.data.values())
         self.assertEqual(response.status_code, 200)
 
-    @patch('api.authentication.auth.verify_id_token')
+    @patch("api.authentication.auth.verify_id_token")
     def test_asset_type_api_endpoint_cant_allow_put(self, mock_verify_id_token):
-        mock_verify_id_token.return_value = {'email': self.admin_user.email}
+        mock_verify_id_token.return_value = {"email": self.admin_user.email}
         data = {"name": "Test Edit", "asset_sub_category": self.asset_sub_category.id}
         response = client.put(
             f"{self.asset_type_url}/{self.asset_type.id}/",
             data=data,
             HTTP_AUTHORIZATION="Token {}".format(self.token_admin),
         )
-        self.assertEqual(response.data.get('name'), 'Test Edit')
+        self.assertEqual(response.data.get("name"), "Test Edit")
 
-    @patch('api.authentication.auth.verify_id_token')
+    @patch("api.authentication.auth.verify_id_token")
     def test_asset_type_api_endpoint_cant_allow_patch(self, mock_verify_id_token):
-        mock_verify_id_token.return_value = {'email': self.admin_user.email}
+        mock_verify_id_token.return_value = {"email": self.admin_user.email}
         data = {}
         response = client.patch(
             self.asset_type_url,
             data=data,
             HTTP_AUTHORIZATION="Token {}".format(self.token_admin),
         )
-        self.assertEqual(response.data, {'detail': 'Method "PATCH" not allowed.'})
+        self.assertEqual(response.data, {"detail": 'Method "PATCH" not allowed.'})
         self.assertEqual(response.status_code, 405)
 
-    @patch('api.authentication.auth.verify_id_token')
+    @patch("api.authentication.auth.verify_id_token")
     def test_asset_type_api_endpoint_cant_allow_delete(self, mock_verify_id_token):
-        mock_verify_id_token.return_value = {'email': self.admin_user.email}
+        mock_verify_id_token.return_value = {"email": self.admin_user.email}
         data = {}
         response = client.delete(
             self.asset_type_url,
             data=data,
             HTTP_AUTHORIZATION="Token {}".format(self.token_admin),
         )
-        self.assertEqual(response.data, {'detail': 'Method "DELETE" not allowed.'})
+        self.assertEqual(response.data, {"detail": 'Method "DELETE" not allowed.'})
         self.assertEqual(response.status_code, 405)
 
-    @patch('api.authentication.auth.verify_id_token')
+    @patch("api.authentication.auth.verify_id_token")
     def test_asset_type_api_orders_asset_types_by_type(self, mock_verify_id_token):
-        mock_verify_id_token.return_value = {'email': self.admin_user.email}
+        mock_verify_id_token.return_value = {"email": self.admin_user.email}
         AssetType.objects.create(name="HP", asset_sub_category=self.asset_sub_category)
         AssetType.objects.create(
             name="Samsung", asset_sub_category=self.asset_sub_category
@@ -110,5 +110,5 @@ class AssetCategoryAPITest(APIBaseTestCase):
         )
         # I am always sure that 'Samsung' will be the last in the response
         #  since the asset types are ordered.
-        self.assertEqual(4, len(response.data.get('results')))
-        self.assertEqual(response.data.get('results')[3].get('name'), "Samsung")
+        self.assertEqual(AssetType.objects.count(), len(response.data.get("results")))
+        self.assertEqual(response.data.get("results")[-1].get("name"), "Samsung")

--- a/api/tests/test_asset_type_api.py
+++ b/api/tests/test_asset_type_api.py
@@ -6,7 +6,7 @@ from rest_framework.test import APIClient
 
 # App Imports
 from api.tests import APIBaseTestCase
-from core.models import AssetCategory, AssetType
+from core.models import AssetType
 
 client = APIClient()
 

--- a/api/views/assets.py
+++ b/api/views/assets.py
@@ -162,7 +162,7 @@ class AssetAssigneeViewSet(ModelViewSet):
 
 class AssetLogViewSet(ModelViewSet):
     serializer_class = AssetLogSerializer
-    queryset = models.AssetLog.objects
+    queryset = models.AssetLog.objects.all()
     permission_classes = [IsAdminUser | IsSecurityUser]
     authentication_classes = (FirebaseTokenAuthentication,)
     filter_backends = (filters.DjangoFilterBackend,)
@@ -171,15 +171,9 @@ class AssetLogViewSet(ModelViewSet):
 
     def get_queryset(self):
         user_location = self.request.user.location
-        query_set = self.queryset.none()
         if user_location:
-            asset_type_name = self.request.query_params.get("asset_type")
-            if asset_type_name is not None:
-                self.queryset = self.queryset.filter(
-                    asset__model_number__asset_make__asset_type__name=asset_type_name
-                )
-            query_set = self.queryset.filter(asset__asset_location=user_location).all()
-        return query_set
+            return self.queryset.filter(asset__asset_location=user_location)
+        return self.queryset.none()
 
     def perform_create(self, serializer):
         serializer.save(checked_by=self.request.user)

--- a/api/views/assets.py
+++ b/api/views/assets.py
@@ -162,7 +162,7 @@ class AssetAssigneeViewSet(ModelViewSet):
 
 class AssetLogViewSet(ModelViewSet):
     serializer_class = AssetLogSerializer
-    queryset = models.AssetLog.objects.all()
+    queryset = models.AssetLog.objects
     permission_classes = [IsAdminUser | IsSecurityUser]
     authentication_classes = (FirebaseTokenAuthentication,)
     filter_backends = (filters.DjangoFilterBackend,)
@@ -171,9 +171,15 @@ class AssetLogViewSet(ModelViewSet):
 
     def get_queryset(self):
         user_location = self.request.user.location
+        query_set = self.queryset.none()
         if user_location:
-            return self.queryset.filter(asset__asset_location=user_location)
-        return self.queryset.none()
+            asset_type_name = self.request.query_params.get("asset_type")
+            if asset_type_name is not None:
+                self.queryset = self.queryset.filter(
+                    asset__model_number__asset_make__asset_type__name=asset_type_name
+                )
+            query_set = self.queryset.filter(asset__asset_location=user_location).all()
+        return query_set
 
     def perform_create(self, serializer):
         serializer.save(checked_by=self.request.user)


### PR DESCRIPTION
### What does this PR do?
Enables filtering asset logs by asset types

### Description of Task to be completed?
Add filtering by asset_type to assetlog queries

#### How should this be manually tested?
1. On browser, goto url reverse('asset-logs-list') and add query string/ parameter specifying the asset_type.

### Any background context you want to provide?
Formerly an admin user could only query for asset logs in their location without filtering by asset type

### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/164827041