### PR TITLE
Add serial number and asset code filter to assetlog query endpoint

### DIFF
--- a/api/filters.py
+++ b/api/filters.py
@@ -76,10 +76,16 @@ class AssetLogFilter(BaseFilter):
         field_name="asset__model_number__asset_make__asset_type__name",
         lookup_expr="iexact",
     )
+    asset_serial = filters.CharFilter(
+        field_name="asset__serial_number", lookup_expr="iexact"
+    )
+    asset_code = filters.CharFilter(
+        field_name="asset__asset_code", lookup_expr="iexact"
+    )
 
     class Meta:
         model = AssetLog
-        fields = ["asset_type"]
+        fields = ["asset_type", "asset_serial", "asset_code"]
 
 
 class UserFilter(BaseFilter):

--- a/api/tests/test_asset_log.py
+++ b/api/tests/test_asset_log.py
@@ -230,6 +230,78 @@ class AssetLogModelTest(APIBaseTestCase):
         )
 
     @patch("api.authentication.auth.verify_id_token")
+    def test_authenticated_admin_user_get_asset_logs_filtered_by_serial_number(
+        self, mock_verify_id_token
+    ):
+        mock_verify_id_token.return_value = {"email": self.admin_user.email}
+        AssetLog.objects.create(
+            checked_by=self.security_user, asset=self.test_other_asset, log_type=CHECKIN
+        )
+        asset_logs_url = (
+            f"{self.asset_logs_url}/?asset_serial={self.test_other_asset.serial_number}"
+        )
+        response = client.get(
+            asset_logs_url, HTTP_AUTHORIZATION=f"Token {self.token_admin}"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertEqual(
+            response.data["results"][0]["asset"],
+            f"{self.test_other_asset.serial_number} - {self.test_other_asset.asset_code}",
+        )
+
+    @patch("api.authentication.auth.verify_id_token")
+    def test_admin_user_get_asset_logs_filtered_by_invalid_serial_number(
+        self, mock_verify_id_token
+    ):
+        mock_verify_id_token.return_value = {"email": self.admin_user.email}
+        AssetLog.objects.create(
+            checked_by=self.security_user, asset=self.test_other_asset, log_type=CHECKIN
+        )
+        asset_logs_url = f"{self.asset_logs_url}/?asset_serial=QWS^&112"
+        response = client.get(
+            asset_logs_url, HTTP_AUTHORIZATION=f"Token {self.token_admin}"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data["results"]), 0)
+
+    @patch("api.authentication.auth.verify_id_token")
+    def test_admin_user_get_asset_logs_filtered_by_asset_code(
+        self, mock_verify_id_token
+    ):
+        mock_verify_id_token.return_value = {"email": self.admin_user.email}
+        AssetLog.objects.create(
+            checked_by=self.security_user, asset=self.test_other_asset, log_type=CHECKIN
+        )
+        asset_logs_url = (
+            f"{self.asset_logs_url}/?asset_code={self.test_other_asset.asset_code}"
+        )
+        response = client.get(
+            asset_logs_url, HTTP_AUTHORIZATION=f"Token {self.token_admin}"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertEqual(
+            response.data["results"][0]["asset"],
+            f"{self.test_other_asset.serial_number} - {self.test_other_asset.asset_code}",
+        )
+
+    @patch("api.authentication.auth.verify_id_token")
+    def test_admin_user_get_asset_logs_filtered_by_invalid_asset_code(
+        self, mock_verify_id_token
+    ):
+        mock_verify_id_token.return_value = {"email": self.admin_user.email}
+        AssetLog.objects.create(
+            checked_by=self.security_user, asset=self.test_other_asset, log_type=CHECKIN
+        )
+        asset_logs_url = f"{self.asset_logs_url}/?asset_serial=CODE1122"
+        response = client.get(
+            asset_logs_url, HTTP_AUTHORIZATION=f"Token {self.token_admin}"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data["results"]), 0)
+
+    @patch("api.authentication.auth.verify_id_token")
     def test_authenticated_admin_user_get_of_asset_logs_invalid_filter(
         self, mock_verify_id_token
     ):

--- a/api/tests/test_asset_log.py
+++ b/api/tests/test_asset_log.py
@@ -258,7 +258,7 @@ class AssetLogModelTest(APIBaseTestCase):
         AssetLog.objects.create(
             checked_by=self.security_user, asset=self.test_other_asset, log_type=CHECKIN
         )
-        asset_logs_url = f"{self.asset_logs_url}/?asset_serial=QWS^&112"
+        asset_logs_url = f"{self.asset_logs_url}/?asset_serial=SERIALDONTEXIST"
         response = client.get(
             asset_logs_url, HTTP_AUTHORIZATION=f"Token {self.token_admin}"
         )
@@ -294,7 +294,7 @@ class AssetLogModelTest(APIBaseTestCase):
         AssetLog.objects.create(
             checked_by=self.security_user, asset=self.test_other_asset, log_type=CHECKIN
         )
-        asset_logs_url = f"{self.asset_logs_url}/?asset_serial=CODE1122"
+        asset_logs_url = f"{self.asset_logs_url}/?asset_serial=CODEDONTEXIST"
         response = client.get(
             asset_logs_url, HTTP_AUTHORIZATION=f"Token {self.token_admin}"
         )


### PR DESCRIPTION
## What does this PR do?
Enable asset-log filtering by asset code and asset serial number

## Description of Task to be completed?
- Update tests for checks that asset logs could be filtered by serial number and asset code.
- Update the asset-log filter to include asset-serial-number and asset-code fields.

## How should this be manually tested?
1. Query for assetlogs using its endpoint (api/v1/asset-logs/?asset_serial=`serial_value`&asset_code=`asset_code_value`\)

## What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/165785995