### PR TITLE
#164101156 Allow an admin to update an incident report's state under external assessment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
             at: ~/art-backend/tmp
         - run:
             name: diff cover
-            command: pipenv run diff-cover tmp/coverage.xml --compare-branch=origin/develop --fail-under=80
+            command: pipenv run diff-cover tmp/coverage.xml --compare-branch=origin/develop --fail-under=90
   deploy_staging:
     <<: *default
     steps:

--- a/api/tests/test_asset_incident_report_api.py
+++ b/api/tests/test_asset_incident_report_api.py
@@ -180,3 +180,23 @@ class AssetIncidentReportAPITest(APIBaseTestCase):
             },
         )
         self.assertEqual(response.status_code, 400)
+
+    @patch('api.authentication.auth.verify_id_token')
+    def test_restrict_patch_of_incident_report_status_for_external_assessment(
+        self, mock_verify_id_token
+    ):
+        mock_verify_id_token.return_value = {'email': self.admin_user.email}
+        data = {
+            "incident_report_state": "external assessment",
+            "asset_state_from_report": "requires external assessment",
+        }
+        response = client.patch(
+            f"{self.incident_report_status_url}",
+            data,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user),
+        )
+        self.assertEqual(
+            response.data,
+            {"Error": "Asset state option is not valid for given report state"},
+        )
+        self.assertEqual(response.status_code, 400)

--- a/api/views/assets.py
+++ b/api/views/assets.py
@@ -576,6 +576,17 @@ class StateTransitionViewset(ModelViewSet):
     def perform_update(self, serializer):
 
         try:
+            report_sate = self.request.data.get("incident_report_state", None)
+            asset_state = self.request.data.get("asset_state_from_report", None)
+            if (
+                report_sate == "external assessment"
+                and asset_state == "requires external assessment"
+            ):
+                raise serializers.ValidationError(
+                    {
+                        "Error": "Asset state option is not valid for given report state"
+                    }
+                )
             serializer.save(
                 incident_report_state=self.request.data.get(
                     "incident_report_state", None

--- a/api/views/assets.py
+++ b/api/views/assets.py
@@ -583,9 +583,7 @@ class StateTransitionViewset(ModelViewSet):
                 and asset_state == "requires external assessment"
             ):
                 raise serializers.ValidationError(
-                    {
-                        "Error": "Asset state option is not valid for given report state"
-                    }
+                    {"Error": "Asset state option is not valid for given report state"}
                 )
             serializer.save(
                 incident_report_state=self.request.data.get(

--- a/api/views/assets.py
+++ b/api/views/assets.py
@@ -575,23 +575,20 @@ class StateTransitionViewset(ModelViewSet):
 
     def perform_update(self, serializer):
 
+        report_state = self.request.data.get("incident_report_state", None)
+        asset_state = self.request.data.get("asset_state_from_report", None)
+        if (
+            report_state == "external assessment"
+            and asset_state == "requires external assessment"
+        ):
+            raise serializers.ValidationError(
+                {"Error": "Asset state option is not valid for given report state"}
+            )
+
         try:
-            report_sate = self.request.data.get("incident_report_state", None)
-            asset_state = self.request.data.get("asset_state_from_report", None)
-            if (
-                report_sate == "external assessment"
-                and asset_state == "requires external assessment"
-            ):
-                raise serializers.ValidationError(
-                    {"Error": "Asset state option is not valid for given report state"}
-                )
             serializer.save(
-                incident_report_state=self.request.data.get(
-                    "incident_report_state", None
-                ),
-                asset_state_from_report=self.request.data.get(
-                    "asset_state_from_report", None
-                ),
+                incident_report_state=report_state,
+                asset_state_from_report=asset_state,
                 partial=True,
             )
         except IntegrityError:


### PR DESCRIPTION
## What does this PR do?
- This PR ensures an admin to mark an asset's status in an incident report (under external assessment) as either `Damaged` or `requires repair`.

## Description of Task to be completed?
Currently, an incident report marked under external assessment can have the asset status also updated to `requires external assessment`. This PR restricts this, therefore, allowing an admin to only mark an asset's status in a report as `Damaged` or `requires repair`.

## How should this be manually tested?
1. On the browser, go to URL `http://127.0.0.1:8000/api/v1/state-transitions/{id}` and update an incident report's state using the format below;

```
{
            "incident_report_state": "external assessment",
            "asset_state": "Damaged",
}
```

A response with the updated information will be returned.
Note: To obtain the status ids, the same URL can be used in conjunction with the get method on a client like Postman or Insomnia.

## What are the relevant pivotal tracker stories?
[#164101156](https://www.pivotaltracker.com/story/show/164101156)
