### PR TITLE
Filter and Paginate assets assigned to a department

### DIFF
--- a/api/filters.py
+++ b/api/filters.py
@@ -63,6 +63,9 @@ class AssetFilter(BaseFilter):
         field_name="current_status", lookup_expr="iexact"
     )
     verified = filters.CharFilter(field_name="verified", lookup_expr="iexact")
+    department = filters.CharFilter(
+        field_name="assigned_to__department__id", lookup_expr="iexact"
+    )
 
     class Meta:
         model = Asset

--- a/api/tests/__init__.py
+++ b/api/tests/__init__.py
@@ -173,6 +173,14 @@ class APIBaseTestCase(TestCase):
             asset_location=cls.centre,
         )
 
+        cls.asset_3 = apps.get_model("core", "Asset").objects.create(
+            asset_code="I0014567830",
+            serial_number="SN01234567871",
+            purchase_date="2019-01-10",
+            model_number=cls.assetmodel,
+            asset_location=cls.centre,
+        )
+
         cls.asset_assignee = apps.get_model("core", "AssetAssignee").objects.get(
             user=cls.user
         )

--- a/api/tests/test_department_api.py
+++ b/api/tests/test_department_api.py
@@ -61,7 +61,8 @@ class DepartmentAPITest(APIBaseTestCase):
             HTTP_AUTHORIZATION="Token {}".format(self.token_user),
         )
         self.assertEqual(
-            response.data, {"name": "Facilities", "id": res.data.get("id")}
+            response.data,
+            {"name": "Facilities", "id": res.data.get("id"), "number_of_assets": 0},
         )
         self.assertEqual(response.status_code, 200)
 
@@ -73,14 +74,9 @@ class DepartmentAPITest(APIBaseTestCase):
         response = client.get(
             department_url, HTTP_AUTHORIZATION="Token {}".format(self.token_user)
         )
-        self.assertEqual(
-            response.data,
-            {
-                "name": self.department.name,
-                "id": self.department.id,
-                "assets_assigned": [],
-            },
-        )
+        self.assertEqual(response.data["name"], self.department.name)
+        self.assertEqual(response.data["id"], self.department.id)
+        self.assertEqual(response.data["assets_assigned"]["results"], [])
         self.assertEqual(response.status_code, 200)
 
     @patch("api.authentication.auth.verify_id_token")
@@ -94,20 +90,23 @@ class DepartmentAPITest(APIBaseTestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            response.data["assets_assigned"][0]["asset_code"], self.asset_2.asset_code
+            response.data["assets_assigned"]["results"][0]["asset_code"],
+            self.asset_2.asset_code,
         )
         self.assertEqual(
-            response.data["assets_assigned"][0]["serial_number"],
+            response.data["assets_assigned"]["results"][0]["serial_number"],
             self.asset_2.serial_number,
         )
         self.assertEqual(
-            response.data["assets_assigned"][0]["asset_type"], self.asset_2.asset_type
+            response.data["assets_assigned"]["results"][0]["asset_type"],
+            self.asset_2.asset_type,
         )
         self.assertEqual(
-            response.data["assets_assigned"][0]["uuid"], str(self.asset_2.uuid)
+            response.data["assets_assigned"]["results"][0]["uuid"],
+            str(self.asset_2.uuid),
         )
         self.assertEqual(
-            response.data["assets_assigned"][0]["asset_category"],
+            response.data["assets_assigned"]["results"][0]["asset_category"],
             self.asset_2.asset_category,
         )
 


### PR DESCRIPTION

#### What does this PR do?
Filter and Paginate assets assigned to a department


#### Description of Task to be completed?
Scenario: Filter and  Paginate department assets
Given an admin with access
When I request to view a long list of assets assigned to a department
Then I should be able to see them in a paginated format
Also on the assets endpoint filter assets by the department.
On the department's endpoint(all and 1), there should be a count on assets a department has


#### How should this be manually tested?
1. On postman, goto http://127.0.0.1:8000/api/v1/departments/<department id> and do a get request. you will see paginated assets assigned.
on the assets endpoint, you can also filter by department to see all assets assigned to departments.
 `http://127.0.0.1:8000/api/v1/assets?department=3`

#### Any background context you want to provide?
Ensure that you have assigned assets to that department first

#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/n/projects/2146417/stories/165930402
