### PR TITLE
#166114088 Asset assignee history

### DIFF
--- a/api/filters.py
+++ b/api/filters.py
@@ -148,16 +148,16 @@ class UserFilter(BaseFilter):
 class AllocationsHistoryFilter(BaseFilter):
     """Filters the allocations"""
 
-    current_owner = filters.CharFilter(
+    owner = filters.CharFilter(
         field_name="current_owner__user__email", lookup_expr="icontains"
     )
-    current_workspace = filters.CharFilter(
+    workspace = filters.CharFilter(
         field_name="current_owner__workspace__id", lookup_expr="iexact"
     )
-    current_department = filters.CharFilter(
+    department = filters.CharFilter(
         field_name="current_owner__department__id", lookup_expr="iexact"
     )
-    asset_serial = filters.CharFilter(
+    asset_serial_number = filters.CharFilter(
         field_name="asset__serial_number", lookup_expr="iexact"
     )
     asset_code = filters.CharFilter(
@@ -167,9 +167,9 @@ class AllocationsHistoryFilter(BaseFilter):
     class Meta:
         model = AllocationHistory
         fields = [
-            "current_owner",
-            "current_workspace",
-            "current_department",
-            "asset_serial",
+            "owner",
+            "workspace",
+            "department",
+            "asset_serial_number",
             "asset_code",
         ]

--- a/api/filters.py
+++ b/api/filters.py
@@ -8,7 +8,7 @@ from django.db.models import Q
 from django_filters import rest_framework as filters
 
 # App Imports
-from core.models import Asset, AssetLog, User
+from core.models import AllocationHistory, Asset, AssetLog, User
 
 logger = logging.getLogger(__name__)
 
@@ -143,3 +143,33 @@ class UserFilter(BaseFilter):
     class Meta:
         model = User
         fields = ["cohort", "email", "asset_count"]
+
+
+class AllocationsHistoryFilter(BaseFilter):
+    """Filters the allocations"""
+
+    current_owner = filters.CharFilter(
+        field_name="current_owner__user__email", lookup_expr="icontains"
+    )
+    current_workspace = filters.CharFilter(
+        field_name="current_owner__workspace__id", lookup_expr="iexact"
+    )
+    current_department = filters.CharFilter(
+        field_name="current_owner__department__id", lookup_expr="iexact"
+    )
+    asset_serial = filters.CharFilter(
+        field_name="asset__serial_number", lookup_expr="iexact"
+    )
+    asset_code = filters.CharFilter(
+        field_name="asset__asset_code", lookup_expr="iexact"
+    )
+
+    class Meta:
+        model = AllocationHistory
+        fields = [
+            "current_owner",
+            "current_workspace",
+            "current_department",
+            "asset_serial",
+            "asset_code",
+        ]

--- a/api/tests/test_allocation_api.py
+++ b/api/tests/test_allocation_api.py
@@ -115,7 +115,7 @@ class AllocationTestCase(APIBaseTestCase):
         self.assertEqual(response.status_code, 200)
 
     @patch("api.authentication.auth.verify_id_token")
-    def test_filter_allocations_by_current_owner(self, mock_verify_id_token):
+    def test_filter_allocations_by_asset_owner(self, mock_verify_id_token):
 
         mock_verify_id_token.return_value = {"email": self.other_user.email}
         data = {"asset": self.asset.id, "current_owner": self.asset_assignee.id}
@@ -124,9 +124,7 @@ class AllocationTestCase(APIBaseTestCase):
             data,
             HTTP_AUTHORIZATION="Token {}".format(self.token_user),
         )
-        allocations_url = (
-            f"{self.allocations_urls}/?current_owner={self.asset_assignee.email}"
-        )
+        allocations_url = f"{self.allocations_urls}/?owner={self.asset_assignee.email}"
         response = client.get(
             allocations_url, HTTP_AUTHORIZATION="Token {}".format(self.token_other_user)
         )
@@ -138,54 +136,50 @@ class AllocationTestCase(APIBaseTestCase):
         self.assertEqual(len(response.data["results"]), count)
 
     @patch("api.authentication.auth.verify_id_token")
-    def test_filter_allocations_by_current_workspace(self, mock_verify_id_token):
+    def test_filter_allocations_by_workspace(self, mock_verify_id_token):
 
         mock_verify_id_token.return_value = {"email": self.other_user.email}
         workspace = OfficeWorkspace.objects.create(
             name="4E", section=self.floor_section
         )
         asset_assignee = AssetAssignee.objects.get(workspace=workspace)
-        data = {"asset": self.asset.id, "current_owner": asset_assignee.id}
+        data = {"asset": self.asset.id, "current_owner": self.asset_assignee.id}
         response = client.post(
             self.allocations_urls,
             data,
             HTTP_AUTHORIZATION="Token {}".format(self.token_user),
         )
-        allocations_url = (
-            f"{self.allocations_urls}/?current_workspace={self.asset_assignee.id}"
-        )
+        allocations_url = f"{self.allocations_urls}/?workspace={asset_assignee.id}"
         response = client.get(
             allocations_url, HTTP_AUTHORIZATION="Token {}".format(self.token_other_user)
         )
 
         self.assertEqual(response.status_code, 200)
         count = AllocationHistory.objects.filter(
-            current_owner=self.asset_assignee.id
+            current_owner=asset_assignee.id
         ).count()
         self.assertEqual(len(response.data["results"]), count)
 
     @patch("api.authentication.auth.verify_id_token")
-    def test_filter_allocations_by_current_department(self, mock_verify_id_token):
+    def test_filter_allocations_by_department(self, mock_verify_id_token):
         mock_verify_id_token.return_value = {"email": self.other_user.email}
 
         department = Department.objects.create(name="Success")
         asset_assignee = AssetAssignee.objects.get(department=department)
-        data = {"asset": self.asset.id, "current_owner": asset_assignee.id}
+        data = {"asset": self.asset.id, "current_owner": self.asset_assignee.id}
         client.post(
             self.allocations_urls,
             data,
             HTTP_AUTHORIZATION="Token {}".format(self.token_user),
         )
-        allocations_url = (
-            f"{self.allocations_urls}/?current_department={asset_assignee.id}"
-        )
+        allocations_url = f"{self.allocations_urls}/?department={asset_assignee.id}"
         response = client.get(
             allocations_url, HTTP_AUTHORIZATION="Token {}".format(self.token_other_user)
         )
 
         self.assertEqual(response.status_code, 200)
         count = AllocationHistory.objects.filter(
-            current_owner=self.asset_assignee.id
+            current_owner=asset_assignee.id
         ).count()
         self.assertEqual(len(response.data["results"]), count)
 
@@ -200,7 +194,7 @@ class AllocationTestCase(APIBaseTestCase):
             HTTP_AUTHORIZATION="Token {}".format(self.token_user),
         )
         allocations_url = (
-            f"{self.allocations_urls}/?asset_serial={self.asset.serial_number}"
+            f"{self.allocations_urls}/?asset_serial_number={self.asset.serial_number}"
         )
         response = client.get(
             allocations_url, HTTP_AUTHORIZATION="Token {}".format(self.token_other_user)

--- a/api/views/assets.py
+++ b/api/views/assets.py
@@ -26,7 +26,7 @@ from rest_framework.viewsets import ModelViewSet
 
 # App Imports
 from api.authentication import FirebaseTokenAuthentication
-from api.filters import AssetFilter, AssetLogFilter
+from api.filters import AllocationsHistoryFilter, AssetFilter, AssetLogFilter
 from api.permissions import IsSecurityUser
 from api.serializers import (
     AllocationsSerializer,
@@ -196,6 +196,7 @@ class AllocationsViewSet(ModelViewSet):
     queryset = models.AllocationHistory.objects.all()
     permission_classes = [IsAuthenticated]
     authentication_classes = (FirebaseTokenAuthentication,)
+    filterset_class = AllocationsHistoryFilter
     http_method_names = ["get", "post"]
 
     def get_queryset(self):


### PR DESCRIPTION
#### What does this PR do?
filters allocation history by owner and asset

#### Description of Task to be completed?
Given an admin with access
When I view an asset
Then I should see the assignee history with timestamps

#### How should this be manually tested?
-fetch the branch git fetch origin ft-filter-asset-logs-164802372
-checkout to the branch git checkout ft-filter-asset-logs-164802372
-visit the endpoints:
     `http://127.0.0.1:8000/api/v1/allocations?current_owner=<email>`
     `http://127.0.0.1:8000/api/v1/allocations?current_workspace=<workspace_id>`
     `http://127.0.0.1:8000/api/v1/allocationst?current_department=<department_id>`
     `http://127.0.0.1:8000/api/v1/allocations?asset_serial=<asset_serial_number>`
     `http://127.0.0.1:8000/api/v1/allocations?asset_code=<asset_code>`



#### Any background context you want to provide?
An asset can be assigned to an andelan, a workspace , and a department

#### What are the relevant pivotal tracker stories?
[#166114088](https://www.pivotaltracker.com/story/show/166114088)