### PR TITLE
user emails should be andela emails

### DIFF
--- a/api/tests/test_user.py
+++ b/api/tests/test_user.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 # Third-Party Imports
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
 from rest_framework.test import APIClient
 
 # App Imports
@@ -89,6 +90,18 @@ class UserTestCase(APIBaseTestCase):
                 password="devpassword",
                 is_staff=True,
                 is_superuser=False,
+            )
+
+    def test_cannot_add_user_without_andela_email(self):
+        with self.assertRaises(ValidationError):
+            User.objects.create(
+                email="wrongemail@gmail.com", cohort=20, password="devpassword"
+            )
+
+    def test_cannot_add_superuser_without_andela_email(self):
+        with self.assertRaises(ValidationError):
+            User.objects.create_superuser(
+                email="bademail@gmail.com", cohort=20, password="devpassword"
             )
 
     def test_non_authenticated_user_add_user_from_api_endpoint(self):

--- a/core/models/user.py
+++ b/core/models/user.py
@@ -39,7 +39,6 @@ class UserManager(BaseUserManager):
     def create_superuser(self, **fields):
         fields.setdefault("is_staff", True)
         fields.setdefault("is_superuser", True)
-
         if fields.get("is_staff") is not True:
             raise ValueError("Superuser must have is_staff=True.")
         if fields.get("is_superuser") is not True:
@@ -77,6 +76,7 @@ class User(AbstractUser):
             raise ValidationError("Only andela email addresses allowed")
 
     def save(self, *args, **kwargs):
+        self.clean()
         self.full_clean()
         try:
             super(User, self).save(*args, **kwargs)


### PR DESCRIPTION

#### What does this PR do?
user emails should be Andela emails


#### Description of Task to be completed?
Enforces only Andela emails to be used in the application


#### How should this be manually tested?
Try creating a superuser or normal user without giving that user an andela email, This will through a validation error.


#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/n/projects/2146417/stories/164753083
