### PR TITLE
Expose port 8000 to docker ports to keep it consistent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,6 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 
-EXPOSE 8080
+EXPOSE 8000
 RUN python manage.py collectstatic --noinput
 ENTRYPOINT ["gunicorn", "art.wsgi"]

--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,4 @@ exec:
 	docker-compose exec art-backend /bin/bash -it
 
 open:
-	open http://0.0.0.0:8080/admin
+	open http://0.0.0.0:8000/admin

--- a/docker-compose.yml.template
+++ b/docker-compose.yml.template
@@ -21,7 +21,7 @@ services:
       CLIENT_EMAIL: "<enter-client-email>"
       DJANGO_SETTINGS_MODULE: "settings.dev"
     ports:
-      - "8080:8080"
+      - "8000:8000"
     entrypoint: ./docker-entrypoint.sh
     depends_on:
       - database

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,4 +9,4 @@ python3 manage.py migrate
 python3 manage.py collectstatic --noinput
 
 # Start The Application
-python3 manage.py runserver 0.0.0.0:8080
+python3 manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
#### What does this PR do?
It updates the port to listen to for request while setting up the project with docker

#### Description of Task to be completed?
Apparently, the https://github.com/AndelaOSP/art-backend/blob/develop/README.md explains that the URL to access the dashboard is `127.0.0.1:8000/admin` which means the port exposed is `8000`. However, when running the app with docker, the port exposed is `8080` which is different from what the README provides.

I changed the port in the docker config to keep it consistent with django's default port which is what is been used when setting up the project without docker.

#### How should this be manually tested?
1. On browser, goto 127.0.0.1:8000



#### Any background context you want to provide?
NA

#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/166766702

#### Postman Documentation
NA

#### Screenshots (If applicable)