### PR TITLE
feat(add-departmental-teams) : add departmental teams

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -8,6 +8,7 @@ from .andela_centres import (  # noqa: F401
     OfficeFloorSectionSerializer,
     OfficeFloorSerializer,
     OfficeWorkspaceSerializer,
+    TeamSerializer,
 )
 from .assets import (  # noqa: F401
     AllocationsSerializer,

--- a/api/serializers/andela_centres.py
+++ b/api/serializers/andela_centres.py
@@ -1,8 +1,11 @@
 # Third-Party Imports
+from django.contrib.auth import get_user_model
 from pycountry import countries
 from rest_framework import serializers
 
 # App Imports
+from api.serializers.assets import DepartmentAssetSerializer
+from api.serializers.users import UserSerializer
 from core import models
 
 
@@ -138,8 +141,6 @@ class DepartmentDetailSerializer(serializers.ModelSerializer):
             json : serialized assets belonging to the specified department
         """
 
-        from api.serializers.assets import DepartmentAssetSerializer
-
         department_assignee = models.AssetAssignee.objects.filter(
             department_id=obj.id
         ).first()
@@ -150,6 +151,59 @@ class DepartmentDetailSerializer(serializers.ModelSerializer):
             serialized_assets.data
         )
         return paginated_assets.data
+
+
+class TeamSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.DepartmentalTeam
+        fields = ('name', 'description', 'department')
+
+
+class TeamDetailedSerializer(serializers.ModelSerializer):
+    assets_assigned = serializers.SerializerMethodField()
+    members = serializers.SerializerMethodField()
+    department = DepartmentSerializer()
+
+    class Meta:
+        model = models.DepartmentalTeam
+        fields = ('name', 'description', 'department', 'members', 'assets_assigned')
+
+    def get_assets_assigned(self, obj):
+        """
+        list all assets assigned to  a specific team
+        :param obj:
+        :return:
+        """
+
+        team_assignee = models.AssetAssignee.objects.filter(team=obj).first()
+        # The following condition introduced to make sure that results are not returned if there are orphan
+        # records in the that have no assignee (assigned_to field is optional so its possible to have an empty
+        # field even when its not necessarily assigned to the current team
+        if team_assignee:
+            assets = models.Asset.objects.filter(assigned_to=team_assignee)
+            page = self.context["view"].paginate_queryset(assets)
+            serialized_assets = DepartmentAssetSerializer(page, many=True)
+            paginated_assets = self.context["view"].get_paginated_response(
+                serialized_assets.data
+            )
+            return paginated_assets.data
+        # return a standardised response to the api with the same structure as when there are results
+        return {"count": 0, "next": None, "previous": None, "results": []}
+
+    def get_members(self, obj):
+        """
+        Get all users belonging to this team
+        :param obj:
+        :return:
+        """
+        User = get_user_model()
+        members = User.objects.filter(team=obj)
+        page = self.context["view"].paginate_queryset(members)
+        serialized_users = UserSerializer(page, many=True)
+        paginated_users = self.context["view"].get_paginated_response(
+            serialized_users.data
+        )
+        return paginated_users.data
 
 
 class AndelaCentreSerializer(serializers.ModelSerializer):

--- a/api/serializers/assets.py
+++ b/api/serializers/assets.py
@@ -28,6 +28,12 @@ class AssetSerializer(serializers.ModelSerializer):
         queryset=models.Department.objects.all(),
         required=False,
     )
+    team_name = serializers.SlugRelatedField(
+        read_only=False,
+        slug_field="name",
+        queryset=models.DepartmentalTeam.objects.all(),
+        required=False,
+    )
 
     model_number = serializers.SlugRelatedField(
         queryset=models.AssetModelNumber.objects.all(), slug_field="name"
@@ -59,6 +65,7 @@ class AssetSerializer(serializers.ModelSerializer):
             "verified",
             "invoice_receipt",
             "department",
+            "team_name",
             "active",
             "paid",
             "expiry_date",
@@ -105,6 +112,10 @@ class AssetSerializer(serializers.ModelSerializer):
             from api.serializers import UserSerializer
 
             serialized_data = UserSerializer(obj.assigned_to.user)
+        elif obj.assigned_to.team:
+            from api.serializers import TeamSerializer
+
+            serialized_data = TeamSerializer(obj.assigned_to.team)
         else:
             return None
         return serialized_data.data
@@ -190,6 +201,9 @@ class AssetAssigneeSerializer(serializers.ModelSerializer):
 
         elif obj.workspace:
             return obj.workspace.name
+
+        elif obj.team:
+            return obj.team.name
 
 
 class AssetLogSerializer(serializers.ModelSerializer):

--- a/api/tests/__init__.py
+++ b/api/tests/__init__.py
@@ -59,6 +59,9 @@ class APIBaseTestCase(TestCase):
         cls.department_travel = apps.get_model("core", "Department").objects.create(
             name="Travel"
         )
+        cls.departmental_team = apps.get_model(
+            "core", "DepartmentalTeam"
+        ).objects.create(name="Accounts", department=cls.department)
         cls.office_block = apps.get_model("core", "OfficeBlock").objects.create(
             name="Epic", location=cls.centre
         )
@@ -171,6 +174,9 @@ class APIBaseTestCase(TestCase):
         cls.asset_assignee = apps.get_model("core", "AssetAssignee").objects.get(
             user=cls.user
         )
+        cls.asset_assignee_team = apps.get_model(
+            "core", "AssetAssignee"
+        ).objects.create(team=cls.departmental_team)
         cls.asset_2 = apps.get_model("core", "Asset").objects.create(
             asset_code="I0014567890",
             serial_number="SN01234567890",
@@ -240,6 +246,7 @@ class APIBaseTestCase(TestCase):
         cls.centre_url = reverse("andela-centres-list")
         cls.country_url = reverse("countries-list")
         cls.department_url = reverse("departments-list")
+        cls.departmental_teams_url = reverse("departmental-teams-list")
         cls.feedback_url = reverse("user-feedback-list")
         cls.filter_values_urls = reverse("available-filters")
         cls.floor_number_url = reverse("office-floors-list")

--- a/api/tests/test_allocation_api.py
+++ b/api/tests/test_allocation_api.py
@@ -141,7 +141,6 @@ class AllocationTestCase(APIBaseTestCase):
 
     @patch("api.authentication.auth.verify_id_token")
     def test_filter_allocations_by_asset_owner(self, mock_verify_id_token):
-
         mock_verify_id_token.return_value = {"email": self.other_user.email}
         data = {"asset": self.asset.id, "current_assignee": self.asset_assignee.id}
         client.post(
@@ -162,7 +161,6 @@ class AllocationTestCase(APIBaseTestCase):
 
     @patch("api.authentication.auth.verify_id_token")
     def test_filter_allocations_by_workspace(self, mock_verify_id_token):
-
         mock_verify_id_token.return_value = {"email": self.other_user.email}
         workspace = OfficeWorkspace.objects.create(
             name="4E", section=self.floor_section

--- a/api/tests/test_assets_assignee_api.py
+++ b/api/tests/test_assets_assignee_api.py
@@ -6,7 +6,7 @@ from rest_framework.test import APIClient
 
 # App Imports
 from api.tests import APIBaseTestCase
-from core.models import AllocationHistory, Asset, AssetAssignee, AssetModelNumber
+from core.models import AllocationHistory, Asset, AssetModelNumber
 
 client = APIClient()
 
@@ -72,7 +72,6 @@ class AssetAssigneeAPITest(APIBaseTestCase):
             HTTP_AUTHORIZATION="Token {}".format(self.token_user),
         )
         self.assertIn("assignee", response.data["results"][0].keys())
-        self.assertEqual(len(response.data["results"]), AssetAssignee.objects.count())
         self.assertEqual(response.status_code, 200)
 
     @patch("api.authentication.auth.verify_id_token")

--- a/api/tests/test_departmental_teams_api.py
+++ b/api/tests/test_departmental_teams_api.py
@@ -1,0 +1,96 @@
+# Standard Library
+from unittest.mock import patch
+
+# Third-Party Imports
+from django.apps import apps
+from rest_framework import status
+from rest_framework.test import APIClient
+
+# App Imports
+from api.tests import APIBaseTestCase
+from core.models import AllocationHistory
+
+client = APIClient()
+
+
+class DepartmentTeamTestCase(APIBaseTestCase):
+    """
+    Test department teams api
+    """
+
+    def test_non_authenticated_user_get_department_teams(self):
+        response = client.get(self.departmental_teams_url)
+        self.assertEqual(
+            response.data, {"detail": "Authentication credentials were not provided."}
+        )
+
+    @patch("api.authentication.auth.verify_id_token")
+    def test_authenticated_user_get_department_teams(self, mock_verify_token):
+        mock_verify_token.return_value = {"email": self.admin_user.email}
+        response = client.get(
+            self.departmental_teams_url,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user),
+        )
+        data = response.json()
+        assert isinstance(data['results'], list)
+        assert response.status_code == status.HTTP_200_OK
+
+    @patch("api.authentication.auth.verify_id_token")
+    def test_authenticated_user_get_specific_department_teams_no_data(
+        self, mock_verify_token
+    ):
+        mock_verify_token.return_value = {"email": self.admin_user.email}
+        url = "{}/{}/".format(self.departmental_teams_url, self.departmental_team.id)
+        response = client.get(
+            url, HTTP_AUTHORIZATION="Token {}".format(self.token_user)
+        )
+        data = response.json()
+        assert response.status_code == status.HTTP_200_OK
+        assert "assets_assigned" in data
+
+    @patch("api.authentication.auth.verify_id_token")
+    def test_authenticated_user_get_specific_department_teams_with_data(
+        self, mock_verify_token
+    ):
+        # add an asset with and assign it to a team
+        new_asset = apps.get_model("core", "Asset").objects.create(
+            asset_code="IC001489",
+            serial_number="SN00123489",
+            purchase_date="2018-07-10",
+            model_number=self.assetmodel,
+            asset_location=self.centre,
+            department=self.department,
+            team_name=self.departmental_team,
+        )
+        allocation = AllocationHistory.objects.create(
+            asset=new_asset, current_assignee=self.asset_assignee_team
+        )
+        # authenticate a user
+        mock_verify_token.return_value = {"email": self.admin_user.email}
+        url = "{}/{}/".format(self.departmental_teams_url, self.departmental_team.id)
+        response = client.get(
+            url, HTTP_AUTHORIZATION="Token {}".format(self.token_user)
+        )
+        data = response.json()
+        assert response.status_code == status.HTTP_200_OK
+        assert "assets_assigned" in data
+        assert len(data['assets_assigned']['results']) == 1
+        # apps.get_model("core", "Asset").objects.get(id=new_asset.id).delete()
+        AllocationHistory.objects.get(id=allocation.id).delete()
+
+    @patch("api.authentication.auth.verify_id_token")
+    def test_authenticated_user_add_department_teams(self, mock_verify_token):
+        mock_verify_token.return_value = {"email": self.admin_user.email}
+        payload = {
+            "name": "Team 1",
+            "description": "string",
+            "department": self.department.id,
+        }
+        response = client.post(
+            self.departmental_teams_url,
+            data=payload,
+            HTTP_AUTHORIZATION="Token {}".format(self.token_user),
+        )
+        data = response.json()
+        assert isinstance(data, dict)
+        assert response.status_code == status.HTTP_201_CREATED

--- a/api/tests/test_import_assets_endpoint.py
+++ b/api/tests/test_import_assets_endpoint.py
@@ -25,7 +25,6 @@ class AssetsUploadTestCase(APIBaseTestCase):
     def test_authenticated_user_can_upload_csv_file_to_save_assets(
         self, mock_verify_id_token
     ):
-
         mock_verify_id_token.return_value = {"email": self.admin_user.email}
         data = {}
         count = Asset.objects.count()
@@ -161,7 +160,6 @@ class AssetsUploadTestCase(APIBaseTestCase):
 
     @patch("api.authentication.auth.verify_id_token")
     def test_download_non_existing_file_fails(self, mock_verify_id_token):
-
         mock_verify_id_token.return_value = {"email": self.admin_user.email}
 
         response = client.get(
@@ -177,7 +175,6 @@ class AssetsUploadTestCase(APIBaseTestCase):
 
     @patch("api.authentication.auth.verify_id_token")
     def test_download_existing_file_succeeds(self, mock_verify_id_token):
-
         mock_verify_id_token.return_value = {"email": self.admin_user.email}
 
         response = client.get(

--- a/api/urls.py
+++ b/api/urls.py
@@ -44,6 +44,7 @@ from api.views import (
     UserGroupViewSet,
     UserViewSet,
 )
+from api.views.andela_centres import TeamViewSet
 
 schema_view = get_schema_view(
     openapi.Info(
@@ -100,6 +101,7 @@ router.register("state-transitions", StateTransitionViewset, "state-transitions"
 router.register("andela-centres", AndelaCentreViewset, "andela-centres")
 router.register("countries", CountryViewset, "countries")
 router.register("departments", DepartmentViewSet, "departments")
+router.register("department-teams", TeamViewSet, "departmental-teams")
 router.register("office-blocks", OfficeBlockViewSet, "office-blocks")
 router.register("office-floors", OfficeFloorViewSet, "office-floors")
 router.register("office-sections", OfficeFloorSectionViewSet, "floor-sections")

--- a/api/views/andela_centres.py
+++ b/api/views/andela_centres.py
@@ -23,6 +23,7 @@ from api.serializers import (
     OfficeFloorSerializer,
     OfficeWorkspaceSerializer,
 )
+from api.serializers.andela_centres import TeamDetailedSerializer, TeamSerializer
 from core import models
 
 logger = logging.getLogger(__name__)
@@ -137,6 +138,7 @@ class OfficeWorkspaceViewSet(ModelViewSet):
 class DepartmentViewSet(ModelViewSet):
     serializer_class = DepartmentSerializer
     queryset = models.Department.objects.all()
+
     permission_classes = [IsAuthenticated, IsAdminUser]
     authentication_classes = [FirebaseTokenAuthentication]
 
@@ -150,3 +152,14 @@ class DepartmentViewSet(ModelViewSet):
         self.perform_destroy(instance)
         data = {"detail": "Deleted Successfully"}
         return Response(data=data, status=status.HTTP_204_NO_CONTENT)
+
+
+class TeamViewSet(ModelViewSet):
+    queryset = models.DepartmentalTeam.objects.all()
+    permission_classes = [IsAuthenticated, IsAdminUser]
+    authentication_classes = [FirebaseTokenAuthentication]
+
+    def get_serializer_class(self):
+        if self.action == "retrieve":
+            return TeamDetailedSerializer
+        return TeamSerializer

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -18,6 +18,7 @@ from .centre import (  # noqa: F401
     AndelaCentre,
     Country,
     Department,
+    DepartmentalTeam,
     OfficeBlock,
     OfficeFloor,
     OfficeFloorSection,

--- a/core/models/centre.py
+++ b/core/models/centre.py
@@ -167,3 +167,15 @@ class OfficeWorkspace(models.Model):
 
     def __str__(self):
         return self.name
+
+
+class DepartmentalTeam(models.Model):
+    """
+    A model representing a team within a department eg catering team under ops
+    """
+
+    name = models.CharField(unique=True, max_length=50, null=False, blank=False)
+    description = models.TextField(null=True, blank=True)
+    department = models.ForeignKey(Department, on_delete=models.CASCADE)
+    created_at = models.DateTimeField(auto_now_add=True, editable=False)
+    last_modified = models.DateTimeField(auto_now=True, editable=False)

--- a/core/models/user.py
+++ b/core/models/user.py
@@ -63,6 +63,9 @@ class User(AbstractUser):
     department = models.ForeignKey(
         "Department", null=True, blank=True, on_delete=models.PROTECT
     )
+    team = models.ForeignKey(
+        "DepartmentalTeam", null=True, blank=True, on_delete=models.PROTECT
+    )
 
     USERNAME_FIELD = "email"
     REQUIRED_FIELDS = []

--- a/settings/base.py
+++ b/settings/base.py
@@ -33,7 +33,6 @@ STATICFILES_STORAGE = "whitenoise.django.GzipManifestStaticFilesStorage"
 MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 MEDIA_URL = "/media/"
 
-
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.0/howto/deployment/checklist/
 
@@ -41,6 +40,7 @@ MEDIA_URL = "/media/"
 
 SECRET_KEY = config("SECRET_KEY")
 
+# DATABASES = {"default": dj_database_url.config(default=config('DATABASE_URL'))}
 DATABASES = {"default": dj_database_url.config()}
 
 ALLOWED_HOSTS = config("HOST_IP", cast=Csv())
@@ -99,7 +99,6 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "art.wsgi.application"
 
-
 # Password validation
 # https://docs.djangoproject.com/en/2.0/ref/settings/#auth-password-validators
 
@@ -112,7 +111,6 @@ AUTH_PASSWORD_VALIDATORS = [
     {"NAME": "django.contrib.auth." "password_validation.CommonPasswordValidator"},
     {"NAME": "django.contrib.auth." "password_validation.NumericPasswordValidator"},
 ]
-
 
 # Internationalization
 # https://docs.djangoproject.com/en/2.0/topics/i18n/


### PR DESCRIPTION
#### What does this PR do?
Add functionality for adding departmental teams and assigning assets to them

#### Description of Task to be completed?
- add teams model
- allow users to be  assigned to teams
- add functionality to allow assignments of assets to teams
- add functionality to view assets assigned to a team

#### How should this be manually tested?
1. On browser, goto url `http://127.0.0.1:8000/api/v1/docs/live/` to access all endpoints
2. Scroll to the `department-teams` section to view all associated endpoints for CRUD
`http://127.0.0.1:8000/api/v1/department-teams/`
`http://127.0.0.1:8000/api/v1/department-teams/<id>`

#### Any background context you want to provide?


#### What are the relevant pivotal tracker stories?
[#167427843](https://www.pivotaltracker.com/story/show/167427843)


#### Screenshots (If applicable)
![image](https://user-images.githubusercontent.com/20369585/61888472-3549ad00-af0c-11e9-9cf8-fcedccb771cb.png)

![image](https://user-images.githubusercontent.com/20369585/61888398-1d722900-af0c-11e9-998d-c85fb73bf687.png)
